### PR TITLE
close #2 PIDを計算する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,12 @@ endif()
 # -------------------
 # Google Test のために、ヘッダファイルのあるディレクトリを指定する？
 include_directories(${PROJECT_SOURCE_DIR}/module)
+include_directories(${PROJECT_SOURCE_DIR}/module/Calculator)
 include_directories(${PROJECT_SOURCE_DIR}/test/dummy)
 include_directories(${GTEST_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/module)
 file(GLOB SRC_FILES
   ${PROJECT_SOURCE_DIR}/module/*.cpp
+  ${PROJECT_SOURCE_DIR}/module/Calculator/*.cpp
   ${PROJECT_SOURCE_DIR}/test/dummy/*.cpp
 )
 add_library(etrobocon2023_impl ${SRC_FILES})

--- a/module/Calculator/Pid.cpp
+++ b/module/Calculator/Pid.cpp
@@ -1,0 +1,46 @@
+/**
+ * @file Pid.cpp
+ * @brief PIDを計算するクラス
+ * @author Negihara
+ */
+
+#include "Pid.h"
+
+PidGain::PidGain(double _kp, double _ki, double _kd) : kp(_kp), ki(_ki), kd(_kd) {}
+
+Pid::Pid(double _kp, double _ki, double _kd, double _targetValue)
+  : gain(_kp, _ki, _kd), preDeviation(0.0), integral(0.0), targetValue(_targetValue)
+{
+}
+
+void Pid::setPidGain(double _kp, double _ki, double _kd)
+{
+  gain.kp = _kp;
+  gain.ki = _ki;
+  gain.kd = _kd;
+}
+
+double Pid::calculatePid(double currentValue, double delta)
+{
+  // 0除算を避けるために0の場合はデフォルト周期0.01とする
+  // delta 周期[ms](デフォルト値0.01[10ms]、省略可)
+  if(delta == 0) delta = 0.01;
+  // 現在の偏差を求める(目標値と現在値の差)
+  double currentDeviation = targetValue - currentValue;
+  // 積分の処理を行う
+  integral += (preDeviation + currentDeviation) * delta / 2;
+  // 微分の処理を行う(偏差の時間(delta)に対する傾きを近似)
+  double difference = (currentDeviation - preDeviation) / delta;
+  // 前回の偏差を更新する
+  preDeviation = currentDeviation;
+
+  // P制御の計算を行う
+  double p = gain.kp * currentDeviation;
+  // I制御の計算を行う
+  double i = gain.ki * integral;
+  // D制御の計算を行う
+  double d = gain.kd * difference;
+
+  // 操作量 = P制御 + I制御 + D制御
+  return (p + i + d);
+}

--- a/module/Calculator/Pid.cpp
+++ b/module/Calculator/Pid.cpp
@@ -1,7 +1,11 @@
 /**
  * @file Pid.cpp
  * @brief PIDを計算するクラス
+<<<<<<< HEAD
  * @author Negihara
+=======
+ * @author Negimarge
+>>>>>>> work-2
  */
 
 #include "Pid.h"
@@ -22,12 +26,21 @@ void Pid::setPidGain(double _kp, double _ki, double _kd)
 
 double Pid::calculatePid(double currentValue, double delta)
 {
+<<<<<<< HEAD
   // 0除算を避けるために0の場合はデフォルト周期0.01とする
   // delta 周期[ms](デフォルト値0.01[10ms]、省略可)
   if(delta == 0) delta = 0.01;
   // 現在の偏差を求める(目標値と現在値の差)
   double currentDeviation = targetValue - currentValue;
   // 積分の処理を行う
+=======
+  // delta 周期[ms](デフォルト値0.01[10ms]、省略可)
+  // 0除算を避けるために0の場合はデフォルト周期0.01とする
+  if(delta == 0) delta = 0.01;
+  // 現在の偏差を求める(目標値と現在値の差)
+  double currentDeviation = targetValue - currentValue;
+  // 積分の処理を行う(前回の誤差上辺、今回の誤差を下辺とする台形の面積を求める)
+>>>>>>> work-2
   integral += (preDeviation + currentDeviation) * delta / 2;
   // 微分の処理を行う(偏差の時間(delta)に対する傾きを近似)
   double difference = (currentDeviation - preDeviation) / delta;
@@ -42,5 +55,9 @@ double Pid::calculatePid(double currentValue, double delta)
   double d = gain.kd * difference;
 
   // 操作量 = P制御 + I制御 + D制御
+<<<<<<< HEAD
   return (p + i + d);
+=======
+  return p + i + d;
+>>>>>>> work-2
 }

--- a/module/Calculator/Pid.cpp
+++ b/module/Calculator/Pid.cpp
@@ -1,11 +1,7 @@
 /**
  * @file Pid.cpp
  * @brief PIDを計算するクラス
-<<<<<<< HEAD
- * @author Negihara
-=======
  * @author Negimarge
->>>>>>> work-2
  */
 
 #include "Pid.h"
@@ -26,21 +22,12 @@ void Pid::setPidGain(double _kp, double _ki, double _kd)
 
 double Pid::calculatePid(double currentValue, double delta)
 {
-<<<<<<< HEAD
-  // 0除算を避けるために0の場合はデフォルト周期0.01とする
-  // delta 周期[ms](デフォルト値0.01[10ms]、省略可)
-  if(delta == 0) delta = 0.01;
-  // 現在の偏差を求める(目標値と現在値の差)
-  double currentDeviation = targetValue - currentValue;
-  // 積分の処理を行う
-=======
   // delta 周期[ms](デフォルト値0.01[10ms]、省略可)
   // 0除算を避けるために0の場合はデフォルト周期0.01とする
   if(delta == 0) delta = 0.01;
   // 現在の偏差を求める(目標値と現在値の差)
   double currentDeviation = targetValue - currentValue;
   // 積分の処理を行う(前回の誤差上辺、今回の誤差を下辺とする台形の面積を求める)
->>>>>>> work-2
   integral += (preDeviation + currentDeviation) * delta / 2;
   // 微分の処理を行う(偏差の時間(delta)に対する傾きを近似)
   double difference = (currentDeviation - preDeviation) / delta;
@@ -55,9 +42,5 @@ double Pid::calculatePid(double currentValue, double delta)
   double d = gain.kd * difference;
 
   // 操作量 = P制御 + I制御 + D制御
-<<<<<<< HEAD
-  return (p + i + d);
-=======
   return p + i + d;
->>>>>>> work-2
 }

--- a/module/Calculator/Pid.h
+++ b/module/Calculator/Pid.h
@@ -1,7 +1,11 @@
 /**
  * @file Pid.h
  * @brief PIDを計算するクラス
+<<<<<<< HEAD
  * @author Negihara
+=======
+ * @author Negimarge
+>>>>>>> work-2
  */
 
 #ifndef PID_H
@@ -33,7 +37,11 @@ class Pid {
   Pid(double _kp, double _ki, double _kd, double _targetValue);
 
   /**
+<<<<<<< HEAD
    * @fn void setPidGain(double _kp, double _ki, double _kd);
+=======
+   * void setPidGain(double _kp, double _ki, double _kd);
+>>>>>>> work-2
    * @brief PIDゲインを設定する
    * @param _kp Pゲイン
    * @param _ki Iゲイン
@@ -42,7 +50,11 @@ class Pid {
   void setPidGain(double _kp, double _ki, double _kd);
 
   /**
+<<<<<<< HEAD
    * @fn double calculatePid(double currentValue, double delta = 0.01);
+=======
+   * double calculatePid(double currentValue, double delta = 0.01);
+>>>>>>> work-2
    * @brief PIDを計算する
    * @param currentValue 現在値
    * @param delta 周期[ms](デフォルト値0.01[10ms]、省略可)

--- a/module/Calculator/Pid.h
+++ b/module/Calculator/Pid.h
@@ -1,0 +1,60 @@
+/**
+ * @file Pid.h
+ * @brief PIDを計算するクラス
+ * @author Negihara
+ */
+
+#ifndef PID_H
+#define PID_H
+
+// PIDゲインを保持する構造体
+struct PidGain {
+ public:
+  double kp;  // Pゲイン
+  double ki;  // Iゲイン
+  double kd;  // Dゲイン
+
+  /** コンストラクタ
+   * @param _kp Pゲイン
+   * @param _ki Iゲイン
+   * @param _kd Dゲイン
+   */
+  PidGain(double _kp, double _ki, double _kd);
+};
+
+class Pid {
+ public:
+  /** コンストラクタ
+   * @param _kp Pゲイン
+   * @param _ki Iゲイン
+   * @param _kd Dゲイン
+   * @param _targetValue 目標値
+   */
+  Pid(double _kp, double _ki, double _kd, double _targetValue);
+
+  /**
+   * @fn void setPidGain(double _kp, double _ki, double _kd);
+   * @brief PIDゲインを設定する
+   * @param _kp Pゲイン
+   * @param _ki Iゲイン
+   * @param _kd Dゲイン
+   */
+  void setPidGain(double _kp, double _ki, double _kd);
+
+  /**
+   * @fn double calculatePid(double currentValue, double delta = 0.01);
+   * @brief PIDを計算する
+   * @param currentValue 現在値
+   * @param delta 周期[ms](デフォルト値0.01[10ms]、省略可)
+   * @return PIDの計算結果(操作量)
+   */
+  double calculatePid(double currentValue, double delta = 0.01);
+
+ private:
+  PidGain gain;
+  double preDeviation;  // 前回の偏差
+  double integral;      // 偏差の累積
+  double targetValue;   // 目標値
+};
+
+#endif

--- a/module/Calculator/Pid.h
+++ b/module/Calculator/Pid.h
@@ -1,7 +1,7 @@
 /**
  * @file Pid.h
  * @brief PIDを計算するクラス
- * @author Negimarge
+ * @author Negimarge kawanoichi
  */
 
 #ifndef PID_H
@@ -33,7 +33,6 @@ class Pid {
   Pid(double _kp, double _ki, double _kd, double _targetValue);
 
   /**
-   * void setPidGain(double _kp, double _ki, double _kd);
    * @brief PIDゲインを設定する
    * @param _kp Pゲイン
    * @param _ki Iゲイン
@@ -42,7 +41,6 @@ class Pid {
   void setPidGain(double _kp, double _ki, double _kd);
 
   /**
-   * double calculatePid(double currentValue, double delta = 0.01);
    * @brief PIDを計算する
    * @param currentValue 現在値
    * @param delta 周期[ms](デフォルト値0.01[10ms]、省略可)

--- a/module/Calculator/Pid.h
+++ b/module/Calculator/Pid.h
@@ -1,11 +1,7 @@
 /**
  * @file Pid.h
  * @brief PIDを計算するクラス
-<<<<<<< HEAD
- * @author Negihara
-=======
  * @author Negimarge
->>>>>>> work-2
  */
 
 #ifndef PID_H
@@ -37,11 +33,7 @@ class Pid {
   Pid(double _kp, double _ki, double _kd, double _targetValue);
 
   /**
-<<<<<<< HEAD
-   * @fn void setPidGain(double _kp, double _ki, double _kd);
-=======
    * void setPidGain(double _kp, double _ki, double _kd);
->>>>>>> work-2
    * @brief PIDゲインを設定する
    * @param _kp Pゲイン
    * @param _ki Iゲイン
@@ -50,11 +42,7 @@ class Pid {
   void setPidGain(double _kp, double _ki, double _kd);
 
   /**
-<<<<<<< HEAD
-   * @fn double calculatePid(double currentValue, double delta = 0.01);
-=======
    * double calculatePid(double currentValue, double delta = 0.01);
->>>>>>> work-2
    * @brief PIDを計算する
    * @param currentValue 現在値
    * @param delta 周期[ms](デフォルト値0.01[10ms]、省略可)

--- a/test/PidTest.cpp
+++ b/test/PidTest.cpp
@@ -213,7 +213,7 @@ namespace etrobocon2023_test {
     double targetValue = 70;
     Pid actualPid(kp, ki, kd, targetValue);
     double currentValue = 60;
-    double currentDeviation = (targetValue - currentValue);                  // 現在の偏差
+    double currentDeviation = (targetValue - currentValue);
     double preDeviation = 0;
     double expected = ((preDeviation + currentDeviation) * DELTA / 2) * ki;  // I制御
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));

--- a/test/PidTest.cpp
+++ b/test/PidTest.cpp
@@ -1,7 +1,11 @@
 /**
  * @file PidTest.cpp
  * @brief PidGainクラス,Pidクラスをテストする
+<<<<<<< HEAD
  * @author Negihara
+=======
+ * @author Negimarge
+>>>>>>> work-2
  */
 
 #include "Pid.h"
@@ -10,6 +14,7 @@
 namespace etrobocon2023_test {
   TEST(PidGainTest, gain)
   {
+<<<<<<< HEAD
     double expected_p = 0.1;
     double expected_i = 0.03;
     double expected_d = 0.612;
@@ -17,10 +22,20 @@ namespace etrobocon2023_test {
     EXPECT_DOUBLE_EQ(expected_p, actualPidGain.kp);
     EXPECT_DOUBLE_EQ(expected_i, actualPidGain.ki);
     EXPECT_DOUBLE_EQ(expected_d, actualPidGain.kd);
+=======
+    double expectedKp = 0.1;
+    double expectedKi = 0.03;
+    double expectedKd = 0.612;
+    PidGain actualPidGain(expectedKp, expectedKi, expectedKd);
+    EXPECT_DOUBLE_EQ(expectedKp, actualPidGain.kp);
+    EXPECT_DOUBLE_EQ(expectedKi, actualPidGain.ki);
+    EXPECT_DOUBLE_EQ(expectedKd, actualPidGain.kd);
+>>>>>>> work-2
   }
 
   TEST(PidGainTest, gainZero)
   {
+<<<<<<< HEAD
     double expected_p = 0.0;
     double expected_i = 0.0;
     double expected_d = 0.0;
@@ -28,10 +43,20 @@ namespace etrobocon2023_test {
     EXPECT_DOUBLE_EQ(expected_p, actualPidGain.kp);
     EXPECT_DOUBLE_EQ(expected_i, actualPidGain.ki);
     EXPECT_DOUBLE_EQ(expected_d, actualPidGain.kd);
+=======
+    double expectedKp = 0.0;
+    double expectedKi = 0.0;
+    double expectedKd = 0.0;
+    PidGain actualPidGain(expectedKp, expectedKi, expectedKd);
+    EXPECT_DOUBLE_EQ(expectedKp, actualPidGain.kp);
+    EXPECT_DOUBLE_EQ(expectedKi, actualPidGain.ki);
+    EXPECT_DOUBLE_EQ(expectedKd, actualPidGain.kd);
+>>>>>>> work-2
   }
 
   TEST(PidGainTest, gainMinus)
   {
+<<<<<<< HEAD
     double expected_p = -0.5;
     double expected_i = -0.2;
     double expected_d = -0.3;
@@ -39,11 +64,21 @@ namespace etrobocon2023_test {
     EXPECT_DOUBLE_EQ(expected_p, actualPidGain.kp);
     EXPECT_DOUBLE_EQ(expected_i, actualPidGain.ki);
     EXPECT_DOUBLE_EQ(expected_d, actualPidGain.kd);
+=======
+    double expectedKp = -0.5;
+    double expectedKi = -0.2;
+    double expectedKd = -0.3;
+    PidGain actualPidGain(expectedKp, expectedKi, expectedKd);
+    EXPECT_DOUBLE_EQ(expectedKp, actualPidGain.kp);
+    EXPECT_DOUBLE_EQ(expectedKi, actualPidGain.ki);
+    EXPECT_DOUBLE_EQ(expectedKd, actualPidGain.kd);
+>>>>>>> work-2
   }
 
   TEST(PidTest, calculatePid)
   {
     constexpr double DELTA = 0.01;
+<<<<<<< HEAD
     double expected_p = 0.6;
     double expected_i = 0.02;
     double expected_d = 0.03;
@@ -56,12 +91,27 @@ namespace etrobocon2023_test {
     double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * expected_i;
     double d = (currentDeviation - preDeviation) * expected_d / DELTA;
     double expected = p + i + d;
+=======
+    double kp = 0.6;
+    double ki = 0.02;
+    double kd = 0.03;
+    double targetValue = 70;
+    Pid actualPid(kp, ki, kd, targetValue);
+    double currentValue = 20;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);
+    double expectedP = currentDeviation * kp;
+    double expectedI = ((preDeviation + currentDeviation) * DELTA / 2.0) * ki;
+    double expectedD = (currentDeviation - preDeviation) * kd / DELTA;
+    double expected = expectedP + expectedI + expectedD;
+>>>>>>> work-2
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
 
   TEST(PidTest, calculatePidZero)
   {
     constexpr double DELTA = 0.01;
+<<<<<<< HEAD
     double expected_p = 0.0;
     double expected_i = 0.0;
     double expected_d = 0.0;
@@ -73,6 +123,19 @@ namespace etrobocon2023_test {
     double p = currentDeviation * expected_p;
     double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * expected_i;
     double d = (currentDeviation - preDeviation) * expected_d / DELTA;
+=======
+    double expectedKp = 0.0;
+    double expectedKi = 0.0;
+    double expectedKd = 0.0;
+    double targetValue = 0;
+    Pid actualPid(expectedKp, expectedKi, expectedKd, targetValue);
+    double currentValue = 40;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);
+    double p = currentDeviation * expectedKp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * expectedKi;
+    double d = (currentDeviation - preDeviation) * expectedKd / DELTA;
+>>>>>>> work-2
     double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
@@ -80,6 +143,7 @@ namespace etrobocon2023_test {
   TEST(PidTest, calculatePidMinus)
   {
     constexpr double DELTA = 0.01;
+<<<<<<< HEAD
     double expected_p = -0.3;
     double expected_i = -0.02;
     double expected_d = -0.175;
@@ -91,6 +155,19 @@ namespace etrobocon2023_test {
     double p = currentDeviation * expected_p;
     double i = ((preDeviation + currentDeviation) * DELTA / 2) * expected_i;
     double d = (currentDeviation - preDeviation) * expected_d / DELTA;
+=======
+    double expectedKp = -0.3;
+    double expectedKi = -0.02;
+    double expectedKd = -0.175;
+    double targetValue = 100;
+    Pid actualPid(expectedKp, expectedKi, expectedKd, targetValue);
+    double currentValue = 0;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);
+    double p = currentDeviation * expectedKp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * expectedKi;
+    double d = (currentDeviation - preDeviation) * expectedKd / DELTA;
+>>>>>>> work-2
     double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
@@ -98,6 +175,7 @@ namespace etrobocon2023_test {
   TEST(PidTest, calculatePidChangeDelta)
   {
     constexpr double DELTA = 0.03;
+<<<<<<< HEAD
     double expected_p = 0.6;
     double expected_i = 0.02;
     double expected_d = 0.03;
@@ -109,6 +187,19 @@ namespace etrobocon2023_test {
     double p = currentDeviation * expected_p;
     double i = ((preDeviation + currentDeviation) * DELTA / 2) * expected_i;
     double d = (currentDeviation - preDeviation) * expected_d / DELTA;
+=======
+    double expectedKp = 0.6;
+    double expectedKi = 0.02;
+    double expectedKd = 0.03;
+    double targetValue = 70;
+    Pid actualPid(expectedKp, expectedKi, expectedKd, targetValue);
+    double currentValue = 55;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);
+    double p = currentDeviation * expectedKp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * expectedKi;
+    double d = (currentDeviation - preDeviation) * expectedKd / DELTA;
+>>>>>>> work-2
     double expected = p + i + d;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
@@ -117,6 +208,7 @@ namespace etrobocon2023_test {
   TEST(PidTest, calculatePidChangeDeltaMinus)
   {
     constexpr double DELTA = -0.03;
+<<<<<<< HEAD
     double expected_p = 0.6;
     double expected_i = 0.02;
     double expected_d = 0.03;
@@ -128,6 +220,19 @@ namespace etrobocon2023_test {
     double p = currentDeviation * expected_p;
     double i = ((preDeviation + currentDeviation) * DELTA / 2) * expected_i;
     double d = (currentDeviation - preDeviation) * expected_d / DELTA;
+=======
+    double expectedKp = 0.6;
+    double expectedKi = 0.02;
+    double expectedKd = 0.03;
+    double targetValue = 70;
+    Pid actualPid(expectedKp, expectedKi, expectedKd, targetValue);
+    double currentValue = 55;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);
+    double p = currentDeviation * expectedKp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * expectedKi;
+    double d = (currentDeviation - preDeviation) * expectedKd / DELTA;
+>>>>>>> work-2
     double expected = p + i + d;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
@@ -137,6 +242,7 @@ namespace etrobocon2023_test {
   TEST(PidTest, calculatePidChangeDeltaZero)
   {
     constexpr double DELTA = 0;              // 実際に渡す周期
+<<<<<<< HEAD
     constexpr double EXPECTED_DELTA = 0.01;  // 期待される周期
     double expected_p = 0.6;
     double expected_i = 0.02;
@@ -149,6 +255,20 @@ namespace etrobocon2023_test {
     double p = currentDeviation * expected_p;
     double i = ((preDeviation + currentDeviation) * EXPECTED_DELTA / 2) * expected_i;
     double d = (currentDeviation - preDeviation) * expected_d / EXPECTED_DELTA;
+=======
+    constexpr double expectedKdELTA = 0.01;  // 期待される周期
+    double expectedKp = 0.6;
+    double expectedKi = 0.02;
+    double expectedKd = 0.03;
+    double targetValue = 70;
+    Pid actualPid(expectedKp, expectedKi, expectedKd, targetValue);
+    double currentValue = 55;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);
+    double p = currentDeviation * expectedKp;
+    double i = ((preDeviation + currentDeviation) * expectedKdELTA / 2) * expectedKi;
+    double d = (currentDeviation - preDeviation) * expectedKd / expectedKdELTA;
+>>>>>>> work-2
     double expected = p + i + d;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
@@ -158,6 +278,7 @@ namespace etrobocon2023_test {
   TEST(PidTest, caluclatePidSetter)
   {
     constexpr double DELTA = 0.01;
+<<<<<<< HEAD
     double expected_p = 0.6;
     double expected_i = 0.05;
     double expected_d = 0.01;
@@ -170,10 +291,25 @@ namespace etrobocon2023_test {
     double i
         = ((preDeviation + currentDeviation) * DELTA / 2) * expected_i;  // I制御(誤差の累積は0)
     double d = (currentDeviation - preDeviation) * expected_d / DELTA;  // D制御(前回の誤差は0)
+=======
+    double expectedKp = 0.6;
+    double expectedKi = 0.05;
+    double expectedKd = 0.01;
+    double targetValue = 70;
+    Pid actualPid(expectedKp, expectedKi, expectedKd, targetValue);
+    double currentValue = 60;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);              // 現在の偏差
+    double p = currentDeviation * expectedKp;                            // P制御
+    double i
+        = ((preDeviation + currentDeviation) * DELTA / 2) * expectedKi;  // I制御(誤差の累積は0)
+    double d = (currentDeviation - preDeviation) * expectedKd / DELTA;  // D制御(前回の誤差は0)
+>>>>>>> work-2
     double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
 
     double integral = (preDeviation + currentDeviation) * DELTA / 2;  // 誤差の累積
+<<<<<<< HEAD
     preDeviation = currentDeviation;            // 前回の誤差の更新
     expected_p = 0.1;
     expected_i = 0.2;
@@ -185,6 +321,19 @@ namespace etrobocon2023_test {
     p = currentDeviation * expected_p;
     i = integral * expected_i;
     d = (currentDeviation - preDeviation) / DELTA * expected_d;
+=======
+    preDeviation = currentDeviation;                                  // 前回の誤差の更新
+    expectedKp = 0.1;
+    expectedKi = 0.2;
+    expectedKd = 0.3;
+    actualPid.setPidGain(expectedKp, expectedKi, expectedKd);  // PIDゲインの更新
+    currentValue = 100;
+    currentDeviation = (targetValue - currentValue);
+    integral += (preDeviation + currentDeviation) * DELTA / 2;
+    p = currentDeviation * expectedKp;
+    i = integral * expectedKi;
+    d = (currentDeviation - preDeviation) / DELTA * expectedKd;
+>>>>>>> work-2
     expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }

--- a/test/PidTest.cpp
+++ b/test/PidTest.cpp
@@ -1,0 +1,192 @@
+/**
+ * @file PidTest.cpp
+ * @brief PidGainクラス,Pidクラスをテストする
+ * @author Negihara
+ */
+
+#include "Pid.h"
+#include <gtest/gtest.h>
+
+namespace etrobocon2023_test {
+  TEST(PidGainTest, gain)
+  {
+    double expected_p = 0.1;
+    double expected_i = 0.03;
+    double expected_d = 0.612;
+    PidGain actualPidGain(expected_p, expected_i, expected_d);
+    EXPECT_DOUBLE_EQ(expected_p, actualPidGain.kp);
+    EXPECT_DOUBLE_EQ(expected_i, actualPidGain.ki);
+    EXPECT_DOUBLE_EQ(expected_d, actualPidGain.kd);
+  }
+
+  TEST(PidGainTest, gainZero)
+  {
+    double expected_p = 0.0;
+    double expected_i = 0.0;
+    double expected_d = 0.0;
+    PidGain actualPidGain(expected_p, expected_i, expected_d);
+    EXPECT_DOUBLE_EQ(expected_p, actualPidGain.kp);
+    EXPECT_DOUBLE_EQ(expected_i, actualPidGain.ki);
+    EXPECT_DOUBLE_EQ(expected_d, actualPidGain.kd);
+  }
+
+  TEST(PidGainTest, gainMinus)
+  {
+    double expected_p = -0.5;
+    double expected_i = -0.2;
+    double expected_d = -0.3;
+    PidGain actualPidGain(expected_p, expected_i, expected_d);
+    EXPECT_DOUBLE_EQ(expected_p, actualPidGain.kp);
+    EXPECT_DOUBLE_EQ(expected_i, actualPidGain.ki);
+    EXPECT_DOUBLE_EQ(expected_d, actualPidGain.kd);
+  }
+
+  TEST(PidTest, calculatePid)
+  {
+    constexpr double DELTA = 0.01;
+    double expected_p = 0.6;
+    double expected_i = 0.02;
+    double expected_d = 0.03;
+    double targetValue = 70;
+    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
+    double currentValue = 20;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);
+    double p = currentDeviation * expected_p;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * expected_i;
+    double d = (currentDeviation - preDeviation) * expected_d / DELTA;
+    double expected = p + i + d;
+    EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
+  }
+
+  TEST(PidTest, calculatePidZero)
+  {
+    constexpr double DELTA = 0.01;
+    double expected_p = 0.0;
+    double expected_i = 0.0;
+    double expected_d = 0.0;
+    double targetValue = 0;
+    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
+    double currentValue = 40;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);
+    double p = currentDeviation * expected_p;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * expected_i;
+    double d = (currentDeviation - preDeviation) * expected_d / DELTA;
+    double expected = p + i + d;
+    EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
+  }
+
+  TEST(PidTest, calculatePidMinus)
+  {
+    constexpr double DELTA = 0.01;
+    double expected_p = -0.3;
+    double expected_i = -0.02;
+    double expected_d = -0.175;
+    double targetValue = 100;
+    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
+    double currentValue = 0;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);
+    double p = currentDeviation * expected_p;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * expected_i;
+    double d = (currentDeviation - preDeviation) * expected_d / DELTA;
+    double expected = p + i + d;
+    EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
+  }
+
+  TEST(PidTest, calculatePidChangeDelta)
+  {
+    constexpr double DELTA = 0.03;
+    double expected_p = 0.6;
+    double expected_i = 0.02;
+    double expected_d = 0.03;
+    double targetValue = 70;
+    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
+    double currentValue = 55;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);
+    double p = currentDeviation * expected_p;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * expected_i;
+    double d = (currentDeviation - preDeviation) * expected_d / DELTA;
+    double expected = p + i + d;
+    // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
+    EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
+  }
+
+  TEST(PidTest, calculatePidChangeDeltaMinus)
+  {
+    constexpr double DELTA = -0.03;
+    double expected_p = 0.6;
+    double expected_i = 0.02;
+    double expected_d = 0.03;
+    double targetValue = 70;
+    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
+    double currentValue = 55;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);
+    double p = currentDeviation * expected_p;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * expected_i;
+    double d = (currentDeviation - preDeviation) * expected_d / DELTA;
+    double expected = p + i + d;
+    // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
+    EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
+  }
+
+  // 周期に0を渡したときに、デフォルト周期0.01として計算されるかをテストする
+  TEST(PidTest, calculatePidChangeDeltaZero)
+  {
+    constexpr double DELTA = 0;              // 実際に渡す周期
+    constexpr double EXPECTED_DELTA = 0.01;  // 期待される周期
+    double expected_p = 0.6;
+    double expected_i = 0.02;
+    double expected_d = 0.03;
+    double targetValue = 70;
+    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
+    double currentValue = 55;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);
+    double p = currentDeviation * expected_p;
+    double i = ((preDeviation + currentDeviation) * EXPECTED_DELTA / 2) * expected_i;
+    double d = (currentDeviation - preDeviation) * expected_d / EXPECTED_DELTA;
+    double expected = p + i + d;
+    // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
+    EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
+  }
+
+  // setしてcalculatePidを呼び出す(Setterのテスト)
+  TEST(PidTest, caluclatePidSetter)
+  {
+    constexpr double DELTA = 0.01;
+    double expected_p = 0.6;
+    double expected_i = 0.05;
+    double expected_d = 0.01;
+    double targetValue = 70;
+    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
+    double currentValue = 60;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);              // 現在の偏差
+    double p = currentDeviation * expected_p;                            // P制御
+    double i
+        = ((preDeviation + currentDeviation) * DELTA / 2) * expected_i;  // I制御(誤差の累積は0)
+    double d = (currentDeviation - preDeviation) * expected_d / DELTA;  // D制御(前回の誤差は0)
+    double expected = p + i + d;
+    EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
+
+    double integral = (preDeviation + currentDeviation) * DELTA / 2;  // 誤差の累積
+    preDeviation = currentDeviation;            // 前回の誤差の更新
+    expected_p = 0.1;
+    expected_i = 0.2;
+    expected_d = 0.3;
+    actualPid.setPidGain(expected_p, expected_i, expected_d);  // PIDゲインの更新
+    currentValue = 100;
+    currentDeviation = (targetValue - currentValue);
+    integral += (preDeviation + currentDeviation) * DELTA / 2;
+    p = currentDeviation * expected_p;
+    i = integral * expected_i;
+    d = (currentDeviation - preDeviation) / DELTA * expected_d;
+    expected = p + i + d;
+    EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
+  }
+
+}  // namespace etrobocon2023_test

--- a/test/PidTest.cpp
+++ b/test/PidTest.cpp
@@ -188,4 +188,51 @@ namespace etrobocon2023_test {
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
 
+  // calculatePidのテスト(pゲイン以外の値が0の場合)
+  TEST(PidTest, caluclateOnlyP)
+  {
+    constexpr double DELTA = 0.01;
+    double kp = 1.0;
+    double ki = 0.0;
+    double kd = 0.0;
+    double targetValue = 70;
+    Pid actualPid(kp, ki, kd, targetValue);
+    double currentValue = 60;
+    double currentDeviation = (targetValue - currentValue);  // 現在の偏差
+    double expected = currentDeviation * kp;                 // P制御
+    EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
+  }
+
+  // calculatePidのテスト(iゲイン以外の値が0の場合)
+  TEST(PidTest, caluclateOnlyI)
+  {
+    constexpr double DELTA = 0.01;
+    double kp = 0.0;
+    double ki = 1.0;
+    double kd = 0.0;
+    double targetValue = 70;
+    Pid actualPid(kp, ki, kd, targetValue);
+    double currentValue = 60;
+    double currentDeviation = (targetValue - currentValue);                  // 現在の偏差
+    double preDeviation = 0;
+    double expected = ((preDeviation + currentDeviation) * DELTA / 2) * ki;  // I制御
+    EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
+  }
+
+  // calculatePidのテスト(dゲイン以外の値が0の場合)
+  TEST(PidTest, caluclateOnlyD)
+  {
+    constexpr double DELTA = 0.01;
+    double kp = 0.0;
+    double ki = 0.0;
+    double kd = 1.0;
+    double targetValue = 70;
+    Pid actualPid(kp, ki, kd, targetValue);
+    double currentValue = 60;
+    double preDeviation = 0;
+    double currentDeviation = (targetValue - currentValue);            // 現在の偏差
+    double expected = (currentDeviation - preDeviation) * kd / DELTA;  // D制御
+    EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
+  }
+
 }  // namespace etrobocon2023_test

--- a/test/PidTest.cpp
+++ b/test/PidTest.cpp
@@ -1,11 +1,7 @@
 /**
  * @file PidTest.cpp
  * @brief PidGainクラス,Pidクラスをテストする
-<<<<<<< HEAD
- * @author Negihara
-=======
  * @author Negimarge
->>>>>>> work-2
  */
 
 #include "Pid.h"
@@ -14,15 +10,6 @@
 namespace etrobocon2023_test {
   TEST(PidGainTest, gain)
   {
-<<<<<<< HEAD
-    double expected_p = 0.1;
-    double expected_i = 0.03;
-    double expected_d = 0.612;
-    PidGain actualPidGain(expected_p, expected_i, expected_d);
-    EXPECT_DOUBLE_EQ(expected_p, actualPidGain.kp);
-    EXPECT_DOUBLE_EQ(expected_i, actualPidGain.ki);
-    EXPECT_DOUBLE_EQ(expected_d, actualPidGain.kd);
-=======
     double expectedKp = 0.1;
     double expectedKi = 0.03;
     double expectedKd = 0.612;
@@ -30,20 +17,10 @@ namespace etrobocon2023_test {
     EXPECT_DOUBLE_EQ(expectedKp, actualPidGain.kp);
     EXPECT_DOUBLE_EQ(expectedKi, actualPidGain.ki);
     EXPECT_DOUBLE_EQ(expectedKd, actualPidGain.kd);
->>>>>>> work-2
   }
 
   TEST(PidGainTest, gainZero)
   {
-<<<<<<< HEAD
-    double expected_p = 0.0;
-    double expected_i = 0.0;
-    double expected_d = 0.0;
-    PidGain actualPidGain(expected_p, expected_i, expected_d);
-    EXPECT_DOUBLE_EQ(expected_p, actualPidGain.kp);
-    EXPECT_DOUBLE_EQ(expected_i, actualPidGain.ki);
-    EXPECT_DOUBLE_EQ(expected_d, actualPidGain.kd);
-=======
     double expectedKp = 0.0;
     double expectedKi = 0.0;
     double expectedKd = 0.0;
@@ -51,20 +28,10 @@ namespace etrobocon2023_test {
     EXPECT_DOUBLE_EQ(expectedKp, actualPidGain.kp);
     EXPECT_DOUBLE_EQ(expectedKi, actualPidGain.ki);
     EXPECT_DOUBLE_EQ(expectedKd, actualPidGain.kd);
->>>>>>> work-2
   }
 
   TEST(PidGainTest, gainMinus)
   {
-<<<<<<< HEAD
-    double expected_p = -0.5;
-    double expected_i = -0.2;
-    double expected_d = -0.3;
-    PidGain actualPidGain(expected_p, expected_i, expected_d);
-    EXPECT_DOUBLE_EQ(expected_p, actualPidGain.kp);
-    EXPECT_DOUBLE_EQ(expected_i, actualPidGain.ki);
-    EXPECT_DOUBLE_EQ(expected_d, actualPidGain.kd);
-=======
     double expectedKp = -0.5;
     double expectedKi = -0.2;
     double expectedKd = -0.3;
@@ -72,26 +39,11 @@ namespace etrobocon2023_test {
     EXPECT_DOUBLE_EQ(expectedKp, actualPidGain.kp);
     EXPECT_DOUBLE_EQ(expectedKi, actualPidGain.ki);
     EXPECT_DOUBLE_EQ(expectedKd, actualPidGain.kd);
->>>>>>> work-2
   }
 
   TEST(PidTest, calculatePid)
   {
     constexpr double DELTA = 0.01;
-<<<<<<< HEAD
-    double expected_p = 0.6;
-    double expected_i = 0.02;
-    double expected_d = 0.03;
-    double targetValue = 70;
-    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
-    double currentValue = 20;
-    double preDeviation = 0;
-    double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * expected_p;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * expected_i;
-    double d = (currentDeviation - preDeviation) * expected_d / DELTA;
-    double expected = p + i + d;
-=======
     double kp = 0.6;
     double ki = 0.02;
     double kd = 0.03;
@@ -104,26 +56,12 @@ namespace etrobocon2023_test {
     double expectedI = ((preDeviation + currentDeviation) * DELTA / 2.0) * ki;
     double expectedD = (currentDeviation - preDeviation) * kd / DELTA;
     double expected = expectedP + expectedI + expectedD;
->>>>>>> work-2
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
 
   TEST(PidTest, calculatePidZero)
   {
     constexpr double DELTA = 0.01;
-<<<<<<< HEAD
-    double expected_p = 0.0;
-    double expected_i = 0.0;
-    double expected_d = 0.0;
-    double targetValue = 0;
-    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
-    double currentValue = 40;
-    double preDeviation = 0;
-    double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * expected_p;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * expected_i;
-    double d = (currentDeviation - preDeviation) * expected_d / DELTA;
-=======
     double expectedKp = 0.0;
     double expectedKi = 0.0;
     double expectedKd = 0.0;
@@ -135,7 +73,6 @@ namespace etrobocon2023_test {
     double p = currentDeviation * expectedKp;
     double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * expectedKi;
     double d = (currentDeviation - preDeviation) * expectedKd / DELTA;
->>>>>>> work-2
     double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
@@ -143,19 +80,6 @@ namespace etrobocon2023_test {
   TEST(PidTest, calculatePidMinus)
   {
     constexpr double DELTA = 0.01;
-<<<<<<< HEAD
-    double expected_p = -0.3;
-    double expected_i = -0.02;
-    double expected_d = -0.175;
-    double targetValue = 100;
-    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
-    double currentValue = 0;
-    double preDeviation = 0;
-    double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * expected_p;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2) * expected_i;
-    double d = (currentDeviation - preDeviation) * expected_d / DELTA;
-=======
     double expectedKp = -0.3;
     double expectedKi = -0.02;
     double expectedKd = -0.175;
@@ -167,7 +91,6 @@ namespace etrobocon2023_test {
     double p = currentDeviation * expectedKp;
     double i = ((preDeviation + currentDeviation) * DELTA / 2) * expectedKi;
     double d = (currentDeviation - preDeviation) * expectedKd / DELTA;
->>>>>>> work-2
     double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
@@ -175,19 +98,6 @@ namespace etrobocon2023_test {
   TEST(PidTest, calculatePidChangeDelta)
   {
     constexpr double DELTA = 0.03;
-<<<<<<< HEAD
-    double expected_p = 0.6;
-    double expected_i = 0.02;
-    double expected_d = 0.03;
-    double targetValue = 70;
-    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
-    double currentValue = 55;
-    double preDeviation = 0;
-    double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * expected_p;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2) * expected_i;
-    double d = (currentDeviation - preDeviation) * expected_d / DELTA;
-=======
     double expectedKp = 0.6;
     double expectedKi = 0.02;
     double expectedKd = 0.03;
@@ -199,7 +109,6 @@ namespace etrobocon2023_test {
     double p = currentDeviation * expectedKp;
     double i = ((preDeviation + currentDeviation) * DELTA / 2) * expectedKi;
     double d = (currentDeviation - preDeviation) * expectedKd / DELTA;
->>>>>>> work-2
     double expected = p + i + d;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
@@ -208,19 +117,6 @@ namespace etrobocon2023_test {
   TEST(PidTest, calculatePidChangeDeltaMinus)
   {
     constexpr double DELTA = -0.03;
-<<<<<<< HEAD
-    double expected_p = 0.6;
-    double expected_i = 0.02;
-    double expected_d = 0.03;
-    double targetValue = 70;
-    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
-    double currentValue = 55;
-    double preDeviation = 0;
-    double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * expected_p;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2) * expected_i;
-    double d = (currentDeviation - preDeviation) * expected_d / DELTA;
-=======
     double expectedKp = 0.6;
     double expectedKi = 0.02;
     double expectedKd = 0.03;
@@ -232,7 +128,6 @@ namespace etrobocon2023_test {
     double p = currentDeviation * expectedKp;
     double i = ((preDeviation + currentDeviation) * DELTA / 2) * expectedKi;
     double d = (currentDeviation - preDeviation) * expectedKd / DELTA;
->>>>>>> work-2
     double expected = p + i + d;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
@@ -242,20 +137,6 @@ namespace etrobocon2023_test {
   TEST(PidTest, calculatePidChangeDeltaZero)
   {
     constexpr double DELTA = 0;              // 実際に渡す周期
-<<<<<<< HEAD
-    constexpr double EXPECTED_DELTA = 0.01;  // 期待される周期
-    double expected_p = 0.6;
-    double expected_i = 0.02;
-    double expected_d = 0.03;
-    double targetValue = 70;
-    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
-    double currentValue = 55;
-    double preDeviation = 0;
-    double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * expected_p;
-    double i = ((preDeviation + currentDeviation) * EXPECTED_DELTA / 2) * expected_i;
-    double d = (currentDeviation - preDeviation) * expected_d / EXPECTED_DELTA;
-=======
     constexpr double expectedKdELTA = 0.01;  // 期待される周期
     double expectedKp = 0.6;
     double expectedKi = 0.02;
@@ -268,7 +149,6 @@ namespace etrobocon2023_test {
     double p = currentDeviation * expectedKp;
     double i = ((preDeviation + currentDeviation) * expectedKdELTA / 2) * expectedKi;
     double d = (currentDeviation - preDeviation) * expectedKd / expectedKdELTA;
->>>>>>> work-2
     double expected = p + i + d;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
@@ -278,20 +158,6 @@ namespace etrobocon2023_test {
   TEST(PidTest, caluclatePidSetter)
   {
     constexpr double DELTA = 0.01;
-<<<<<<< HEAD
-    double expected_p = 0.6;
-    double expected_i = 0.05;
-    double expected_d = 0.01;
-    double targetValue = 70;
-    Pid actualPid(expected_p, expected_i, expected_d, targetValue);
-    double currentValue = 60;
-    double preDeviation = 0;
-    double currentDeviation = (targetValue - currentValue);              // 現在の偏差
-    double p = currentDeviation * expected_p;                            // P制御
-    double i
-        = ((preDeviation + currentDeviation) * DELTA / 2) * expected_i;  // I制御(誤差の累積は0)
-    double d = (currentDeviation - preDeviation) * expected_d / DELTA;  // D制御(前回の誤差は0)
-=======
     double expectedKp = 0.6;
     double expectedKi = 0.05;
     double expectedKd = 0.01;
@@ -304,24 +170,10 @@ namespace etrobocon2023_test {
     double i
         = ((preDeviation + currentDeviation) * DELTA / 2) * expectedKi;  // I制御(誤差の累積は0)
     double d = (currentDeviation - preDeviation) * expectedKd / DELTA;  // D制御(前回の誤差は0)
->>>>>>> work-2
     double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
 
     double integral = (preDeviation + currentDeviation) * DELTA / 2;  // 誤差の累積
-<<<<<<< HEAD
-    preDeviation = currentDeviation;            // 前回の誤差の更新
-    expected_p = 0.1;
-    expected_i = 0.2;
-    expected_d = 0.3;
-    actualPid.setPidGain(expected_p, expected_i, expected_d);  // PIDゲインの更新
-    currentValue = 100;
-    currentDeviation = (targetValue - currentValue);
-    integral += (preDeviation + currentDeviation) * DELTA / 2;
-    p = currentDeviation * expected_p;
-    i = integral * expected_i;
-    d = (currentDeviation - preDeviation) / DELTA * expected_d;
-=======
     preDeviation = currentDeviation;                                  // 前回の誤差の更新
     expectedKp = 0.1;
     expectedKi = 0.2;
@@ -333,7 +185,6 @@ namespace etrobocon2023_test {
     p = currentDeviation * expectedKp;
     i = integral * expectedKi;
     d = (currentDeviation - preDeviation) / DELTA * expectedKd;
->>>>>>> work-2
     expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }

--- a/test/PidTest.cpp
+++ b/test/PidTest.cpp
@@ -52,10 +52,10 @@ namespace etrobocon2023_test {
     double currentValue = 20;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double expectedP = currentDeviation * kp;
-    double expectedI = ((preDeviation + currentDeviation) * DELTA / 2.0) * ki;
-    double expectedD = (currentDeviation - preDeviation) * kd / DELTA;
-    double expected = expectedP + expectedI + expectedD;
+    double p = currentDeviation * kp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * ki;
+    double d = (currentDeviation - preDeviation) * kd / DELTA;
+    double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
 
@@ -70,10 +70,10 @@ namespace etrobocon2023_test {
     double currentValue = 40;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double expectedP = currentDeviation * kp;
-    double expectedI = ((preDeviation + currentDeviation) * DELTA / 2.0) * ki;
-    double expectedD = (currentDeviation - preDeviation) * kd / DELTA;
-    double expected = expectedP + expectedI + expectedD;
+    double p = currentDeviation * kp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * ki;
+    double d = (currentDeviation - preDeviation) * kd / DELTA;
+    double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
 
@@ -88,10 +88,10 @@ namespace etrobocon2023_test {
     double currentValue = 0;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double expectedP = currentDeviation * kp;
-    double expectedI = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
-    double expectedD = (currentDeviation - preDeviation) * kd / DELTA;
-    double expected = expectedP + expectedI + expectedD;
+    double p = currentDeviation * kp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
+    double d = (currentDeviation - preDeviation) * kd / DELTA;
+    double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
 
@@ -106,10 +106,10 @@ namespace etrobocon2023_test {
     double currentValue = 55;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double expectedP = currentDeviation * kp;
-    double expectedI = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
-    double expectedD = (currentDeviation - preDeviation) * kd / DELTA;
-    double expected = expectedP + expectedI + expectedD;
+    double p = currentDeviation * kp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
+    double d = (currentDeviation - preDeviation) * kd / DELTA;
+    double expected = p + i + d;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
   }
@@ -125,10 +125,10 @@ namespace etrobocon2023_test {
     double currentValue = 55;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double expectedP = currentDeviation * kp;
-    double expectedI = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
-    double expectedD = (currentDeviation - preDeviation) * kd / DELTA;
-    double expected = expectedP + expectedI + expectedD;
+    double p = currentDeviation * kp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
+    double d = (currentDeviation - preDeviation) * kd / DELTA;
+    double expected = p + i + d;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
   }
@@ -146,10 +146,10 @@ namespace etrobocon2023_test {
     double currentValue = 55;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double expectedP = currentDeviation * kp;
-    double expectedI = ((preDeviation + currentDeviation) * kdELTA / 2) * ki;
-    double expectedD = (currentDeviation - preDeviation) * kd / kdELTA;
-    double expected = expectedP + expectedI + expectedD;
+    double p = currentDeviation * kp;
+    double i = ((preDeviation + currentDeviation) * kdELTA / 2) * ki;
+    double d = (currentDeviation - preDeviation) * kd / kdELTA;
+    double expected = p + i + d;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
   }
@@ -165,12 +165,11 @@ namespace etrobocon2023_test {
     Pid actualPid(kp, ki, kd, targetValue);
     double currentValue = 60;
     double preDeviation = 0;
-    double currentDeviation = (targetValue - currentValue);      // 現在の偏差
-    double expectedP = currentDeviation * kp;                    // P制御
-    double expectedI
-        = ((preDeviation + currentDeviation) * DELTA / 2) * ki;  // I制御(誤差の累積は0)
-    double expectedD = (currentDeviation - preDeviation) * kd / DELTA;  // D制御(前回の誤差は0)
-    double expected = expectedP + expectedI + expectedD;
+    double currentDeviation = (targetValue - currentValue);           // 現在の偏差
+    double p = currentDeviation * kp;                                 // P制御
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * ki;  // I制御(誤差の累積は0)
+    double d = (currentDeviation - preDeviation) * kd / DELTA;  // D制御(前回の誤差は0)
+    double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
 
     double integral = (preDeviation + currentDeviation) * DELTA / 2;  // 誤差の累積
@@ -182,10 +181,10 @@ namespace etrobocon2023_test {
     currentValue = 100;
     currentDeviation = (targetValue - currentValue);
     integral += (preDeviation + currentDeviation) * DELTA / 2;
-    expectedP = currentDeviation * kp;
-    expectedI = integral * ki;
-    expectedD = (currentDeviation - preDeviation) / DELTA * kd;
-    expected = expectedP + expectedI + expectedD;
+    p = currentDeviation * kp;
+    i = integral * ki;
+    d = (currentDeviation - preDeviation) / DELTA * kd;
+    expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
 

--- a/test/PidTest.cpp
+++ b/test/PidTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @file PidTest.cpp
  * @brief PidGainクラス,Pidクラスをテストする
- * @author Negimarge
+ * @author Negimarge kawanoichi
  */
 
 #include "Pid.h"
@@ -70,10 +70,10 @@ namespace etrobocon2023_test {
     double currentValue = 40;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * kp;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * ki;
-    double d = (currentDeviation - preDeviation) * kd / DELTA;
-    double expected = p + i + d;
+    double expectedP = currentDeviation * kp;
+    double expectedI = ((preDeviation + currentDeviation) * DELTA / 2.0) * ki;
+    double expectedD = (currentDeviation - preDeviation) * kd / DELTA;
+    double expected = expectedP + expectedI + expectedD;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
 
@@ -88,10 +88,10 @@ namespace etrobocon2023_test {
     double currentValue = 0;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * kp;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
-    double d = (currentDeviation - preDeviation) * kd / DELTA;
-    double expected = p + i + d;
+    double expectedP = currentDeviation * kp;
+    double expectedI = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
+    double expectedD = (currentDeviation - preDeviation) * kd / DELTA;
+    double expected = expectedP + expectedI + expectedD;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
 
@@ -106,10 +106,10 @@ namespace etrobocon2023_test {
     double currentValue = 55;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * kp;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
-    double d = (currentDeviation - preDeviation) * kd / DELTA;
-    double expected = p + i + d;
+    double expectedP = currentDeviation * kp;
+    double expectedI = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
+    double expectedD = (currentDeviation - preDeviation) * kd / DELTA;
+    double expected = expectedP + expectedI + expectedD;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
   }
@@ -125,10 +125,10 @@ namespace etrobocon2023_test {
     double currentValue = 55;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * kp;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
-    double d = (currentDeviation - preDeviation) * kd / DELTA;
-    double expected = p + i + d;
+    double expectedP = currentDeviation * kp;
+    double expectedI = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
+    double expectedD = (currentDeviation - preDeviation) * kd / DELTA;
+    double expected = expectedP + expectedI + expectedD;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
   }
@@ -146,10 +146,10 @@ namespace etrobocon2023_test {
     double currentValue = 55;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * kp;
-    double i = ((preDeviation + currentDeviation) * kdELTA / 2) * ki;
-    double d = (currentDeviation - preDeviation) * kd / kdELTA;
-    double expected = p + i + d;
+    double expectedP = currentDeviation * kp;
+    double expectedI = ((preDeviation + currentDeviation) * kdELTA / 2) * ki;
+    double expectedD = (currentDeviation - preDeviation) * kd / kdELTA;
+    double expected = expectedP + expectedI + expectedD;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
   }
@@ -165,11 +165,12 @@ namespace etrobocon2023_test {
     Pid actualPid(kp, ki, kd, targetValue);
     double currentValue = 60;
     double preDeviation = 0;
-    double currentDeviation = (targetValue - currentValue);           // 現在の偏差
-    double p = currentDeviation * kp;                                 // P制御
-    double i = ((preDeviation + currentDeviation) * DELTA / 2) * ki;  // I制御(誤差の累積は0)
-    double d = (currentDeviation - preDeviation) * kd / DELTA;  // D制御(前回の誤差は0)
-    double expected = p + i + d;
+    double currentDeviation = (targetValue - currentValue);      // 現在の偏差
+    double expectedP = currentDeviation * kp;                    // P制御
+    double expectedI
+        = ((preDeviation + currentDeviation) * DELTA / 2) * ki;  // I制御(誤差の累積は0)
+    double expectedD = (currentDeviation - preDeviation) * kd / DELTA;  // D制御(前回の誤差は0)
+    double expected = expectedP + expectedI + expectedD;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
 
     double integral = (preDeviation + currentDeviation) * DELTA / 2;  // 誤差の累積
@@ -181,10 +182,10 @@ namespace etrobocon2023_test {
     currentValue = 100;
     currentDeviation = (targetValue - currentValue);
     integral += (preDeviation + currentDeviation) * DELTA / 2;
-    p = currentDeviation * kp;
-    i = integral * ki;
-    d = (currentDeviation - preDeviation) / DELTA * kd;
-    expected = p + i + d;
+    expectedP = currentDeviation * kp;
+    expectedI = integral * ki;
+    expectedD = (currentDeviation - preDeviation) / DELTA * kd;
+    expected = expectedP + expectedI + expectedD;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
 

--- a/test/PidTest.cpp
+++ b/test/PidTest.cpp
@@ -62,17 +62,17 @@ namespace etrobocon2023_test {
   TEST(PidTest, calculatePidZero)
   {
     constexpr double DELTA = 0.01;
-    double expectedKp = 0.0;
-    double expectedKi = 0.0;
-    double expectedKd = 0.0;
+    double kp = 0.0;
+    double ki = 0.0;
+    double kd = 0.0;
     double targetValue = 0;
-    Pid actualPid(expectedKp, expectedKi, expectedKd, targetValue);
+    Pid actualPid(kp, ki, kd, targetValue);
     double currentValue = 40;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * expectedKp;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * expectedKi;
-    double d = (currentDeviation - preDeviation) * expectedKd / DELTA;
+    double p = currentDeviation * kp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2.0) * ki;
+    double d = (currentDeviation - preDeviation) * kd / DELTA;
     double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
@@ -80,17 +80,17 @@ namespace etrobocon2023_test {
   TEST(PidTest, calculatePidMinus)
   {
     constexpr double DELTA = 0.01;
-    double expectedKp = -0.3;
-    double expectedKi = -0.02;
-    double expectedKd = -0.175;
+    double kp = -0.3;
+    double ki = -0.02;
+    double kd = -0.175;
     double targetValue = 100;
-    Pid actualPid(expectedKp, expectedKi, expectedKd, targetValue);
+    Pid actualPid(kp, ki, kd, targetValue);
     double currentValue = 0;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * expectedKp;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2) * expectedKi;
-    double d = (currentDeviation - preDeviation) * expectedKd / DELTA;
+    double p = currentDeviation * kp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
+    double d = (currentDeviation - preDeviation) * kd / DELTA;
     double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }
@@ -98,17 +98,17 @@ namespace etrobocon2023_test {
   TEST(PidTest, calculatePidChangeDelta)
   {
     constexpr double DELTA = 0.03;
-    double expectedKp = 0.6;
-    double expectedKi = 0.02;
-    double expectedKd = 0.03;
+    double kp = 0.6;
+    double ki = 0.02;
+    double kd = 0.03;
     double targetValue = 70;
-    Pid actualPid(expectedKp, expectedKi, expectedKd, targetValue);
+    Pid actualPid(kp, ki, kd, targetValue);
     double currentValue = 55;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * expectedKp;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2) * expectedKi;
-    double d = (currentDeviation - preDeviation) * expectedKd / DELTA;
+    double p = currentDeviation * kp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
+    double d = (currentDeviation - preDeviation) * kd / DELTA;
     double expected = p + i + d;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
@@ -117,17 +117,17 @@ namespace etrobocon2023_test {
   TEST(PidTest, calculatePidChangeDeltaMinus)
   {
     constexpr double DELTA = -0.03;
-    double expectedKp = 0.6;
-    double expectedKi = 0.02;
-    double expectedKd = 0.03;
+    double kp = 0.6;
+    double ki = 0.02;
+    double kd = 0.03;
     double targetValue = 70;
-    Pid actualPid(expectedKp, expectedKi, expectedKd, targetValue);
+    Pid actualPid(kp, ki, kd, targetValue);
     double currentValue = 55;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * expectedKp;
-    double i = ((preDeviation + currentDeviation) * DELTA / 2) * expectedKi;
-    double d = (currentDeviation - preDeviation) * expectedKd / DELTA;
+    double p = currentDeviation * kp;
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * ki;
+    double d = (currentDeviation - preDeviation) * kd / DELTA;
     double expected = p + i + d;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
@@ -136,19 +136,19 @@ namespace etrobocon2023_test {
   // 周期に0を渡したときに、デフォルト周期0.01として計算されるかをテストする
   TEST(PidTest, calculatePidChangeDeltaZero)
   {
-    constexpr double DELTA = 0;              // 実際に渡す周期
-    constexpr double expectedKdELTA = 0.01;  // 期待される周期
-    double expectedKp = 0.6;
-    double expectedKi = 0.02;
-    double expectedKd = 0.03;
+    constexpr double DELTA = 0;      // 実際に渡す周期
+    constexpr double kdELTA = 0.01;  // 期待される周期
+    double kp = 0.6;
+    double ki = 0.02;
+    double kd = 0.03;
     double targetValue = 70;
-    Pid actualPid(expectedKp, expectedKi, expectedKd, targetValue);
+    Pid actualPid(kp, ki, kd, targetValue);
     double currentValue = 55;
     double preDeviation = 0;
     double currentDeviation = (targetValue - currentValue);
-    double p = currentDeviation * expectedKp;
-    double i = ((preDeviation + currentDeviation) * expectedKdELTA / 2) * expectedKi;
-    double d = (currentDeviation - preDeviation) * expectedKd / expectedKdELTA;
+    double p = currentDeviation * kp;
+    double i = ((preDeviation + currentDeviation) * kdELTA / 2) * ki;
+    double d = (currentDeviation - preDeviation) * kd / kdELTA;
     double expected = p + i + d;
     // 第2引数に周期を渡し、周期に応じた計算結果を返すことができるかを確認(デフォルトでは0.01が渡される)
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue, DELTA));
@@ -158,33 +158,32 @@ namespace etrobocon2023_test {
   TEST(PidTest, caluclatePidSetter)
   {
     constexpr double DELTA = 0.01;
-    double expectedKp = 0.6;
-    double expectedKi = 0.05;
-    double expectedKd = 0.01;
+    double kp = 0.6;
+    double ki = 0.05;
+    double kd = 0.01;
     double targetValue = 70;
-    Pid actualPid(expectedKp, expectedKi, expectedKd, targetValue);
+    Pid actualPid(kp, ki, kd, targetValue);
     double currentValue = 60;
     double preDeviation = 0;
-    double currentDeviation = (targetValue - currentValue);              // 現在の偏差
-    double p = currentDeviation * expectedKp;                            // P制御
-    double i
-        = ((preDeviation + currentDeviation) * DELTA / 2) * expectedKi;  // I制御(誤差の累積は0)
-    double d = (currentDeviation - preDeviation) * expectedKd / DELTA;  // D制御(前回の誤差は0)
+    double currentDeviation = (targetValue - currentValue);           // 現在の偏差
+    double p = currentDeviation * kp;                                 // P制御
+    double i = ((preDeviation + currentDeviation) * DELTA / 2) * ki;  // I制御(誤差の累積は0)
+    double d = (currentDeviation - preDeviation) * kd / DELTA;  // D制御(前回の誤差は0)
     double expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
 
     double integral = (preDeviation + currentDeviation) * DELTA / 2;  // 誤差の累積
     preDeviation = currentDeviation;                                  // 前回の誤差の更新
-    expectedKp = 0.1;
-    expectedKi = 0.2;
-    expectedKd = 0.3;
-    actualPid.setPidGain(expectedKp, expectedKi, expectedKd);  // PIDゲインの更新
+    kp = 0.1;
+    ki = 0.2;
+    kd = 0.3;
+    actualPid.setPidGain(kp, ki, kd);  // PIDゲインの更新
     currentValue = 100;
     currentDeviation = (targetValue - currentValue);
     integral += (preDeviation + currentDeviation) * DELTA / 2;
-    p = currentDeviation * expectedKp;
-    i = integral * expectedKi;
-    d = (currentDeviation - preDeviation) / DELTA * expectedKd;
+    p = currentDeviation * kp;
+    i = integral * ki;
+    d = (currentDeviation - preDeviation) / DELTA * kd;
     expected = p + i + d;
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));
   }


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
etrobocon2023/moduleの直下にCalculatorフォルダ(etrobocon2023/module/Calculator/)を作成し、
そこに以下の2つのファイルを追加。
- Pid.cpp
- Pid.h

etrobocon2023/testに以下のファイルを追加。
- PidTest.cpp

etrobocon2023/のCMakeLists.txtに以下の参照先を追加。
- include_directories(${PROJECT_SOURCE_DIR}/module/Calculator)
- ${PROJECT_SOURCE_DIR}/module/Calculator/*.cpp

# 動作テスト
PidTest.cppのテストに通りました。

フォーマットは保存する時、通しているはずなのですが、何故通らないのかわかりません
## 添付資料
