### PR TITLE
close #13 コースの左右、目標輝度の設定

### DIFF
--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -13,7 +13,7 @@ void Calibrator::run()
   // 左右ボタンでコースのLRを選択する
   selectCourse();
 
-  // 黒と白の輝度を測定して目標輝度を求める
+  // 目標輝度を測定する
   measureTargetBrightness();
 }
 
@@ -75,7 +75,7 @@ void Calibrator::waitForStart()
 
   printf("On standby.\n");  // TODO logger.hを作成したら、printfをlogger.logに変更
   snprintf(buf, BUF_SIZE, "On standby.\n\nSignal within %dcm from Sonar Sensor.", startDistance);
-  printf("%s", buf);  // TODO logger.hを作成したら、printfをlogger.logに変更
+  printf("%s", buf);        // TODO logger.hを作成したら、printfをlogger.logに変更
 
   // startDistance以内の距離に物体がない間待機する
   while(measurer.getForwardDistance() > startDistance) {

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -75,7 +75,7 @@ void Calibrator::waitForStart()
 
   printf("On standby.\n");  // TODO logger.hを作成したら、printfをlogger.logに変更
   snprintf(buf, BUF_SIZE, "On standby.\n\nSignal within %dcm from Sonar Sensor.", startDistance);
-  printf("%s", buf);        // TODO logger.hを作成したら、printfをlogger.logに変更
+  printf("%s", buf);  // TODO logger.hを作成したら、printfをlogger.logに変更
 
   // startDistance以内の距離に物体がない間待機する
   while(measurer.getForwardDistance() > startDistance) {

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -1,0 +1,94 @@
+/**
+ * @file Calibrator.cpp
+ * @brief キャリブレーションからスタートまでを担当するクラス
+ * @author aridome222
+ */
+
+#include "Calibrator.h"
+
+Calibrator::Calibrator() : isLeftCourse(true), targetBrightness(50) {}
+
+void Calibrator::run()
+{
+  // 左右ボタンでコースのLRを選択する
+  selectCourse();
+
+  // 黒と白の輝度を測定して目標輝度を求める
+  measureTargetBrightness();
+}
+
+void Calibrator::selectCourse()
+{
+  const int BUF_SIZE = 128;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+  bool _isLeftCourse = true;
+
+  printf("Select a Course");     // TODO logger.hを作成したら、printfをlogger.logに変更
+  printf(">> Set Left Course");  // TODO logger.hを作成したら、printfをlogger.logに変更
+  // 中央ボタンが押されたら確定する
+  while(!measurer.getEnterButton()) {
+    // 左ボタンが押されたらLコースをセットする
+    if(measurer.getLeftButton() && !_isLeftCourse) {
+      _isLeftCourse = true;
+      printf(">> Set Left Course");  // TODO logger.hを作成したら、printfをlogger.logに変更
+    }
+
+    // 右ボタンが押されたらRコースをセットする
+    if(measurer.getRightButton() && _isLeftCourse) {
+      _isLeftCourse = false;
+      printf(">> Set Right Course");  // TODO logger.hを作成したら、printfをlogger.logに変更
+    }
+
+    timer.sleep();  // 10ミリ秒スリープ
+  }
+
+  isLeftCourse = _isLeftCourse;
+  const char* course = isLeftCourse ? "Left" : "Right";
+  snprintf(buf, BUF_SIZE, "\nWill Run on the %s Course\n", course);
+  printf("%s", buf);  // TODO logger.hを作成したら、printfをlogger.logHighlightに変更
+
+  timer.sleep(1000);  // 1秒スリープ
+}
+
+void Calibrator::measureTargetBrightness()
+{
+  const int BUF_SIZE = 128;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+
+  // ライン上で中央ボタンを押して、黒と白の中間色の輝度を取得する
+  printf("Press the Center Button on the Line");  // TODO
+                                                  // logger.hを作成したら、printfをlogger.logに変更
+  // 中央ボタンが押されるまで待機
+  while(!measurer.getEnterButton()) {
+    timer.sleep();  // 10ミリ秒スリープ
+  }
+  targetBrightness = measurer.getBrightness();
+  snprintf(buf, BUF_SIZE, ">> Target Brightness Value is %d", targetBrightness);
+  printf("%s", buf);  // TODO logger.hを作成したら、printfをlogger.logに変更
+}
+
+void Calibrator::waitForStart()
+{
+  const int BUF_SIZE = 128;
+  char buf[BUF_SIZE];               // log用にメッセージを一時保持する領域
+  constexpr int startDistance = 5;  // 手などでスタート合図を出す距離[cm]
+
+  printf("On standby.\n");  // TODO logger.hを作成したら、printfをlogger.logに変更
+  snprintf(buf, BUF_SIZE, "On standby.\n\nSignal within %dcm from Sonar Sensor.", startDistance);
+  printf("%s", buf);        // TODO logger.hを作成したら、printfをlogger.logに変更
+
+  // startDistance以内の距離に物体がない間待機する
+  while(measurer.getForwardDistance() > startDistance) {
+    timer.sleep();  // 10ミリ秒スリープ
+  }
+}
+
+bool Calibrator::getIsLeftCourse()
+{
+  return isLeftCourse;
+}
+
+int Calibrator::getTargetBrightness()
+{
+  return targetBrightness;
+}

--- a/module/Calibrator.h
+++ b/module/Calibrator.h
@@ -1,0 +1,59 @@
+/**
+ * @file Calibrator.h
+ * @brief キャリブレーションからスタートまでを担当するクラス
+ * @author aridome222
+ */
+
+#ifndef CALIBRATOR_H
+#define CALIBRATOR_H
+
+#include "Measurer.h"
+#include "Timer.h"
+
+class Calibrator {
+ public:
+  /**
+   * コンストラクタ
+   */
+  Calibrator();
+
+  /**
+   * キャリブレーション処理（入力系）をまとめて実行する
+   */
+  void run();
+
+  /**
+   * スタート合図が出るまで待機状態にする
+   */
+  void waitForStart();
+
+  /**
+   * isLeftCourseのゲッター
+   * @return true:Lコース, false:Rコース
+   */
+  bool getIsLeftCourse();
+
+  /**
+   * targetBrightnessのゲッター
+   * @return 目標輝度
+   */
+  int getTargetBrightness();
+
+ private:
+  bool isLeftCourse;     // true:左コース, false: 右コース
+  int targetBrightness;  // 目標輝度
+  static Measurer measurer;
+  Timer timer;
+
+  /**
+   * 左右ボタンでLRコースを選択してisLeftCourseをセットする
+   */
+  void selectCourse();
+
+  /**
+   * 黒と白の輝度を測定して目標輝度を求めtargetBrightnessをセットする
+   */
+  void measureTargetBrightness();
+};
+
+#endif

--- a/module/Calibrator.h
+++ b/module/Calibrator.h
@@ -40,7 +40,7 @@ class Calibrator {
   int getTargetBrightness();
 
  private:
-  bool isLeftCourse;     // true:左コース, false: 右コース
+  bool isLeftCourse;     // true:Lコース, false: Rコース
   int targetBrightness;  // 目標輝度
   static Measurer measurer;
   Timer timer;

--- a/test/CalibratorTest.cpp
+++ b/test/CalibratorTest.cpp
@@ -1,0 +1,93 @@
+/**
+ * @file CalibratorTest.cpp
+ * @brief Calibratorクラスのテスト
+ * @author aridome222
+ */
+
+#include "Calibrator.h"
+#include <gtest/gtest.h>
+#include <gtest/internal/gtest-port.h>
+#include <time.h>
+
+using namespace std;
+
+namespace etrobocon2023_test {
+
+  TEST(CalibratorTest, run)
+  {
+    Calibrator calibrator;
+    srand(2);  // SPIKEの電圧が標準値でLeftコースを選択する乱数シード
+    testing::internal::CaptureStdout();                      // 標準出力キャプチャ開始
+    calibrator.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // find("str")はstrが見つからない場合string::nposを返す
+    bool actual = output.find("Will Run on the Left Course") != string::npos
+                  && output.find("Warning") == string::npos  // Warningがない
+                  && output.find("Error") == string::npos;   // Errorがない
+
+    EXPECT_TRUE(actual);  // 期待した出力がされており，WarningやErrorが出ていないかテスト
+  }
+
+  TEST(CalibratorTest, waitForStart)
+  {
+    Calibrator calibrator;
+    testing::internal::CaptureStdout();                      // 標準出力キャプチャ開始
+    calibrator.waitForStart();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // find("str")はstrが見つからない場合string::nposを返す
+    bool actual = output.find("On standby.\n\nSignal within 5cm from Sonar Sensor.") != string::npos
+                  && output.find("Warning") == string::npos  // Warningがない
+                  && output.find("Error") == string::npos;   // Errorがない
+
+    EXPECT_TRUE(actual);  // 期待した出力がされており，WarningやErrorが出ていないかテスト
+  }
+
+  TEST(CalibratorTest, getIsLeftCourse)
+  {
+    Calibrator calibrator;
+    srand((unsigned int)time(NULL));     // 現在時刻を元に乱数シードを生成
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    calibrator.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+    bool expected;
+
+    // Leftコースと出力されていた場合
+    if(output.find("Will Run on the Left Course") != string::npos) {
+      expected = true;  // Lコース
+    }
+    // Rightコースと出力されていた場合
+    else if(output.find("Will Run on the Right Course") != string::npos) {
+      expected = false;  // Rコース
+    }
+    // 想定していない状況
+    else {
+      expected = NULL;
+    }
+
+    bool actual = calibrator.getIsLeftCourse();  // 実際のisLeftCourseを取得
+
+    EXPECT_EQ(expected, actual);                 // 出力とゲッタの値が等しいかテスト
+  }
+
+  TEST(CalibratorTest, getTargetBrightness)
+  {
+    Calibrator calibrator;
+    srand((unsigned int)time(NULL));     // 現在時刻を元に乱数シードを生成
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    calibrator.run();
+    string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    string targetString = "Target Brightness Value is ";  // 目標輝度値の直前に書かれている文字列
+
+    // 出力された目標輝度値を取得
+    int index = output.find(targetString) + targetString.length();
+    string expectedStr = output.substr(index);      // 輝度値を取得（文字列）
+    int expected = stoi(expectedStr);               // 文字列を整数値に変換
+
+    int actual = calibrator.getTargetBrightness();  // 実際の輝度値を取得
+
+    EXPECT_EQ(expected, actual);  // 出力とゲッタの値が等しいかテスト
+  }
+}  // namespace etrobocon2023_test

--- a/test/CalibratorTest.cpp
+++ b/test/CalibratorTest.cpp
@@ -17,7 +17,7 @@ namespace etrobocon2023_test {
   {
     Calibrator calibrator;
     srand(2);  // SPIKEの電圧が標準値でLeftコースを選択する乱数シード
-    testing::internal::CaptureStdout();                      // 標準出力キャプチャ開始
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
     calibrator.run();
     string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
 
@@ -32,7 +32,7 @@ namespace etrobocon2023_test {
   TEST(CalibratorTest, waitForStart)
   {
     Calibrator calibrator;
-    testing::internal::CaptureStdout();                      // 標準出力キャプチャ開始
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
     calibrator.waitForStart();
     string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
 
@@ -68,7 +68,7 @@ namespace etrobocon2023_test {
 
     bool actual = calibrator.getIsLeftCourse();  // 実際のisLeftCourseを取得
 
-    EXPECT_EQ(expected, actual);                 // 出力とゲッタの値が等しいかテスト
+    EXPECT_EQ(expected, actual);  // 出力とゲッタの値が等しいかテスト
   }
 
   TEST(CalibratorTest, getTargetBrightness)
@@ -83,8 +83,8 @@ namespace etrobocon2023_test {
 
     // 出力された目標輝度値を取得
     int index = output.find(targetString) + targetString.length();
-    string expectedStr = output.substr(index);      // 輝度値を取得（文字列）
-    int expected = stoi(expectedStr);               // 文字列を整数値に変換
+    string expectedStr = output.substr(index);  // 輝度値を取得（文字列）
+    int expected = stoi(expectedStr);           // 文字列を整数値に変換
 
     int actual = calibrator.getTargetBrightness();  // 実際の輝度値を取得
 

--- a/test/dummy/SonarSensor.cpp
+++ b/test/dummy/SonarSensor.cpp
@@ -8,7 +8,7 @@
 using namespace ev3api;
 
 // コンストラクタ
-SonarSensor::SonarSensor(ePortS port) : distance(100) {}
+SonarSensor::SonarSensor(ePortS port) : distance(3) {}
 
 // センサーまでの距離を取得
 int SonarSensor::getDistance()

--- a/test/dummy/SonarSensor.cpp
+++ b/test/dummy/SonarSensor.cpp
@@ -13,12 +13,5 @@ SonarSensor::SonarSensor(ePortS port) : distance(3) {}
 // センサーまでの距離を取得
 int SonarSensor::getDistance()
 {
-  // 呼び出すたびにdistanceを1引く（0~100）
-  if(distance == 0) {
-    distance = 100;
-  } else {
-    distance--;
-  }
-
   return distance;
 }


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
module下に以下のファイルを追加。
- Calibrator.cpp
- Calibrator.h

test/gtest下に以下のテストファイルを追加。
- CalibratorTest.cpp

test/dummy下の以下のファイルを変更。
- SonarSensor.cpp

# 動作テスト
CalibratorTest.cppは無事通りました。
ただ、
Calibrator.cppのvoid Calibrator::waitForStart()内で、
「startDistance以内の距離に物体がない間待機する」という処理が行われており、

```
constexpr int startDistance = 5;  // 手などでスタート合図を出す距離[cm]

while(measurer.getForwardDistance() > startDistance) {

   timer.sleep();  // 10ミリ秒スリープ
}
```

measurer.getForwardDistance()がstartDistanceよりも大きいために永久にスリープしてテストが止まっていたので、measurer.getForwardDistance()で得られるdistanceをSonarSensor.cpp内で、

`SonarSensor::SonarSensor(ePortS port) : distance(100) {}`
となっていたのを、

`SonarSensor::SonarSensor(ePortS port) : distance(3) {}`
に変更することで、スリープ状態を解決しました。

## 添付資料
