### PR TITLE
close #11 指定速度に相当するPWM値を算出するSpeedCalculatorの追加

### DIFF
--- a/module/API/Controller.cpp
+++ b/module/API/Controller.cpp
@@ -1,9 +1,12 @@
 /**
  * @file Controller.cpp
  * @brief モーター制御に用いる関数をまとめたラッパークラス
- * @author aridome222
+ * @author aridome222 miyahita64 bizyutyu
  */
 #include "Controller.h"
+ev3api::Motor* Controller::rightMotor = nullptr;
+ev3api::Motor* Controller::leftMotor = nullptr;
+ev3api::Motor* Controller::armMotor = nullptr;
 
 int Controller::limitPwmValue(const int value)
 {
@@ -18,30 +21,30 @@ int Controller::limitPwmValue(const int value)
 // 右モータにPWM値をセット
 void Controller::setRightMotorPwm(const int pwm)
 {
-  ev3api::Motor(rightWheelPort).setPWM(limitPwmValue(pwm));
+  rightMotor->setPWM(limitPwmValue(pwm));
 }
 
 // 左モータにPWM値をセット
 void Controller::setLeftMotorPwm(const int pwm)
 {
-  ev3api::Motor(leftWheelPort).setPWM(limitPwmValue(pwm));
+  leftMotor->setPWM(limitPwmValue(pwm));
 }
 
 // タイヤのモータを停止する
 void Controller::stopMotor()
 {
-  ev3api::Motor(leftWheelPort).stop();
-  ev3api::Motor(rightWheelPort).stop();
+  rightMotor->stop();
+  leftMotor->stop();
 }
 
 // アームのモータにPWM値をセット
 void Controller::setArmMotorPwm(const int pwm)
 {
-  ev3api::Motor(armMotorPort).setPWM(limitPwmValue(pwm));
+  armMotor->setPWM(limitPwmValue(pwm));
 }
 
 // アームのモータを停止する
 void Controller::stopArmMotor()
 {
-  ev3api::Motor(armMotorPort).stop();
+  armMotor->stop();
 }

--- a/module/API/Controller.cpp
+++ b/module/API/Controller.cpp
@@ -4,6 +4,7 @@
  * @author aridome222 miyahita64 bizyutyu
  */
 #include "Controller.h"
+
 ev3api::Motor* Controller::rightMotor = nullptr;
 ev3api::Motor* Controller::leftMotor = nullptr;
 ev3api::Motor* Controller::armMotor = nullptr;

--- a/module/API/Controller.h
+++ b/module/API/Controller.h
@@ -1,7 +1,7 @@
 /**
  * @file Controller.h
  * @brief モーター制御に用いる関数をまとめたラッパークラス
- * @author aridome222
+ * @author aridome222 miyashita64 bizyutyu
  */
 #ifndef CONTROLLER_H
 #define CONTROLLER_H
@@ -11,6 +11,13 @@
 
 class Controller {
  public:
+  static const ePortM rightWheelPort = PORT_B;
+  static const ePortM leftWheelPort = PORT_C;
+  static const ePortM armMotorPort = PORT_A;
+  static ev3api::Motor* rightMotor;
+  static ev3api::Motor* leftMotor;
+  static ev3api::Motor* armMotor;
+
   Controller() = delete;  // 明示的にインスタンス化を禁止
 
   /**
@@ -39,10 +46,6 @@ class Controller {
  private:
   static const int MOTOR_PWM_MAX = 100;
   static const int MOTOR_PWM_MIN = -100;
-
-  static const ePortM rightWheelPort = PORT_B;
-  static const ePortM leftWheelPort = PORT_A;
-  static const ePortM armMotorPort = PORT_C;
 
   /**
    * モータに設定するPWM値の制限

--- a/module/Calculator/SpeedCalculator.cpp
+++ b/module/Calculator/SpeedCalculator.cpp
@@ -1,0 +1,47 @@
+/**
+ *  @file SpeedCalculator.cpp
+ *  @brief 走行速度を指定するクラス
+ *  @author miyashita64 bizyutyu
+ */
+#include "SpeedCalculator.h"
+
+SpeedCalculator::SpeedCalculator(double _targetSpeed)
+  : targetSpeed(_targetSpeed), pid(0.001, 0.000000001, 0.0001, _targetSpeed)
+{
+  pwm = 0.0;
+  int rightAngle = Measurer::getRightCount();
+  int leftAngle = Measurer::getLeftCount();
+  prevMileage = Mileage::calculateMileage(rightAngle, leftAngle);
+  prevTime = timer.now();
+}
+
+int SpeedCalculator::calcPwmFromSpeed()
+{
+  // 左右タイヤの回転角度を取得
+  int rightAngle = Measurer::getRightCount();
+  int leftAngle = Measurer::getLeftCount();
+  // 走行距離を算出
+  double currentMileage = Mileage::calculateMileage(rightAngle, leftAngle);
+  double diffMileage = currentMileage - prevMileage;
+  // 走行時間を算出
+  int currentTime = timer.now();
+  double diffTime = (double)(currentTime - prevTime);
+  // 走行速度を算出
+  double currentSpeed = (diffMileage == 0.0) ? -targetSpeed : calcSpeed(diffMileage, diffTime);
+  // 走行速度に相当するPWM値を算出
+  pwm += pid.calculatePid(currentSpeed, diffTime);
+  // メンバを更新
+  prevMileage = currentMileage;
+  prevTime = currentTime;
+
+  return (int)pwm;
+}
+
+double SpeedCalculator::calcSpeed(double diffMileage, double diffTime)
+{
+  // 走行時間が0のとき、0を返す
+  if(diffTime == 0.0) return 0.0;
+  // 走行速度を算出
+  double speed = 1000.0 * diffMileage / diffTime;
+  return speed;
+}

--- a/module/Calculator/SpeedCalculator.cpp
+++ b/module/Calculator/SpeedCalculator.cpp
@@ -41,7 +41,7 @@ double SpeedCalculator::calcSpeed(double diffMileage, double diffTime)
 {
   // 走行時間が0のとき、0を返す
   if(diffTime == 0.0) return 0.0;
-  // 走行速度を算出
-  double speed = diffMileage / (diffTime * 0.001);
+  // 走行速度[mm/s]を算出(= 1000 * mm / ms)
+  double speed = 1000 * diffMileage / diffTime;
   return speed;
 }

--- a/module/Calculator/SpeedCalculator.cpp
+++ b/module/Calculator/SpeedCalculator.cpp
@@ -42,6 +42,6 @@ double SpeedCalculator::calcSpeed(double diffMileage, double diffTime)
   // 走行時間が0のとき、0を返す
   if(diffTime == 0.0) return 0.0;
   // 走行速度を算出
-  double speed = 1000.0 * diffMileage / diffTime;
+  double speed = diffMileage / (diffTime / 1000.0);
   return speed;
 }

--- a/module/Calculator/SpeedCalculator.cpp
+++ b/module/Calculator/SpeedCalculator.cpp
@@ -42,6 +42,6 @@ double SpeedCalculator::calcSpeed(double diffMileage, double diffTime)
   // 走行時間が0のとき、0を返す
   if(diffTime == 0.0) return 0.0;
   // 走行速度を算出
-  double speed = diffMileage / (diffTime / 1000.0);
+  double speed = diffMileage / (diffTime * 0.001);
   return speed;
 }

--- a/module/Calculator/SpeedCalculator.h
+++ b/module/Calculator/SpeedCalculator.h
@@ -1,0 +1,46 @@
+/**
+ * @file SpeedCalculator.h
+ * @brief 走行速度を指定するクラス
+ * @author miyashita64 bizyutyu
+ */
+
+#ifndef SPEED_CALCULATOR_H
+#define SPEED_CALCULATOR_H
+
+#include "Measurer.h"
+#include "Controller.h"
+#include "Mileage.h"
+#include "Pid.h"
+#include "Timer.h"
+
+class SpeedCalculator {
+ public:
+  /**
+   * @brief コンストラクタ
+   * @param _targetSpeed 目標とする走行速度[mm/s]
+   */
+  SpeedCalculator(double _targetSpeed);
+
+  /**
+   * @brief 目標とする走行速度に相当するPWM値を算出する
+   * @return 走行体全体の累計走行距離[mm]
+   */
+  int calcPwmFromSpeed();
+
+ private:
+  Pid pid;
+  Timer timer;
+  const double targetSpeed;
+  double pwm;
+  double prevMileage;
+  int prevTime;
+
+  /**
+   * @brief 走行速度を算出する
+   * @param diffMileage 移動距離[mm/s]
+   * @param diffTime 移動時間[ms]
+   * @return 走行速度[mm/s]
+   */
+  double calcSpeed(double diffMileage, double diffTime);
+};
+#endif

--- a/module/Calculator/SpeedCalculator.h
+++ b/module/Calculator/SpeedCalculator.h
@@ -23,7 +23,7 @@ class SpeedCalculator {
 
   /**
    * @brief 目標とする走行速度に相当するPWM値を算出する
-   * @return 走行体全体の累計走行距離[mm]
+   * @return 走行速度に相当するPWM値
    */
   int calcPwmFromSpeed();
 
@@ -37,7 +37,7 @@ class SpeedCalculator {
 
   /**
    * @brief 走行速度を算出する
-   * @param diffMileage 移動距離[mm/s]
+   * @param diffMileage 移動距離[mm]
    * @param diffTime 移動時間[ms]
    * @return 走行速度[mm/s]
    */

--- a/module/EtRobocon2023.cpp
+++ b/module/EtRobocon2023.cpp
@@ -1,65 +1,21 @@
 /**
  * @file   EtRobocon2023.cpp
  * @brief  全体を制御するクラス
- * @author KakinokiKanta
+ * @author KakinokiKanta miyashita64 bizyutyu
  */
 
 #include "EtRobocon2023.h"
-// #include "LineTraceArea.h"
-// #include "GameArea.h"
-// #include "Calibrator.h"
+// ev3api.hをインクルードしているものは.cppに書く
+#include "ev3api.h"
+#include "Motor.h"
+#include "Controller.h"
 
 void EtRobocon2023::start()
 {
-  // const int BUF_SIZE = 128;
-  // char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
-  // Logger logger;
-
-  // bool isLeftCourse = true;
-  // bool isLeftEdge = true;
-  // int targetBrightness = (WHITE_BRIGHTNESS + BLACK_BRIGHTNESS) / 2;
-  // Calibrator calibrator;
-
-  // // 強制終了(CTRL+C)のシグナルを登録する
-  // signal(SIGINT, sigint);
-
-  // // サーバを起動する
-  // system("bash ./etrobocon2023/scripts/serve.sh &");
-
-  // // キャリブレーションする
-  // calibrator.run();
-  // isLeftCourse = calibrator.getIsLeftCourse();
-  // isLeftEdge = isLeftCourse;
-  // targetBrightness = calibrator.getTargetBrightness();
-
-  // // 合図を送るまで待機する
-  // calibrator.waitForStart();
-
-  // // カメラシステムに開始合図を送る
-  // system("bash ./etrobocon2023/scripts/start.sh");
-
-  // // スタートのメッセージログを出す
-  // const char* course = isLeftCourse ? "Left" : "Right";
-  // snprintf(buf, BUF_SIZE, "\nRun on the %s Course\n", course);
-  // logger.logHighlight(buf);
-
-  // // ライントレースエリアを走行する
-  // LineTraceArea::runLineTraceArea(isLeftCourse, isLeftEdge, targetBrightness);
-
-  // // ゲームエリアを攻略する
-  // GameArea::runGameArea(isLeftCourse, isLeftEdge, targetBrightness);
-
-  // // 走行終了のメッセージログを出す
-  // logger.logHighlight("The run has been completed\n");
-
-  // // ログファイルを生成する
-  // logger.outputToFile();
+  ev3api::Motor _rightWheel(Controller::rightWheelPort);
+  ev3api::Motor _leftWheel(Controller::leftWheelPort);
+  ev3api::Motor _armMotor(Controller::armMotorPort);
+  Controller::rightMotor = &_rightWheel;
+  Controller::leftMotor = &_leftWheel;
+  Controller::armMotor = &_armMotor;
 }
-
-// void EtRobocon2023::sigint(int _)
-// {
-//   Logger logger;
-//   logger.log("Forced termination.");  // 強制終了のログを出力
-//   logger.outputToFile();              // ログファイルを生成
-//   _exit(0);                           //システムコールで強制終了
-// }

--- a/module/EtRobocon2023.h
+++ b/module/EtRobocon2023.h
@@ -1,15 +1,13 @@
 /**
  * @file   EtRobocon2023.h
  * @brief  全体を制御するクラス
- * @author KakinokiKanta
+ * @author KakinokiKanta miyashita64 bizyutyu
  */
 
 #ifndef ETROBOCON2023_H
 #define ETROBOCON2023_H
 
 // ev3api.hを読み込むヘッダは.cppに記述する
-// #include "SystemInfo.h"
-// #include "Logger.h"
 #include <signal.h>
 #include <unistd.h>
 

--- a/test/ControllerTest.cpp
+++ b/test/ControllerTest.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file ControllerTest.cpp
+ * @brief Controllerクラスをテストする
+ * @author miyashita64 bizyutu
+ */
+
+#include "ev3api.h"
+#include "Controller.h"
+#include <gtest/gtest.h>
+
+namespace etrobocon2023_test {
+  TEST(ControllerTest, setRightMotorPwm)
+  {
+    const int pwm = 50;
+    ev3api::Motor _rightWheel(Controller::rightWheelPort);
+    ev3api::Motor _leftWheel(Controller::leftWheelPort);
+    ev3api::Motor _armMotor(Controller::armMotorPort);
+    Controller::rightMotor = &_rightWheel;
+    Controller::leftMotor = &_leftWheel;
+    Controller::armMotor = &_armMotor;
+    Controller::setRightMotorPwm(pwm);
+    Controller::rightMotor->reset();
+    SUCCEED();
+  }
+
+  TEST(ControllerTest, setLeftMotorPwm)
+  {
+    const int pwm = 50;
+    Controller::setLeftMotorPwm(pwm);
+    Controller::leftMotor->reset();
+    SUCCEED();
+  }
+
+  TEST(ControllerTest, stopMotor)
+  {
+    Controller::stopMotor();
+    SUCCEED();
+  }
+
+  TEST(ControllerTest, setArmMotorPwm)
+  {
+    const int pwm = 50;
+    Controller::setArmMotorPwm(pwm);
+    Controller::armMotor->reset();
+    SUCCEED();
+  }
+
+  TEST(ControllerTest, stopArmMotor)
+  {
+    Controller::stopArmMotor();
+    SUCCEED();
+  }
+
+}  // namespace etrobocon2023_test

--- a/test/SpeedCalculatorTest.cpp
+++ b/test/SpeedCalculatorTest.cpp
@@ -1,0 +1,31 @@
+/**
+ * @file SpeedCalculatorTest.cpp
+ * @brief SpeedCalculatorクラスをテストする
+ * @author miyashita64 bizyutu
+ */
+
+#include "SpeedCalculator.h"
+#include <gtest/gtest.h>
+
+namespace etrobocon2023_test {
+  TEST(SpeedCalculatorTest, calcPwmFromSpeed)
+  {
+    SpeedCalculator speedCalc(300.0);
+    int actualPwm = speedCalc.calcPwmFromSpeed();
+    EXPECT_LT(0, actualPwm);
+  }
+
+  TEST(SpeedCalculatorTest, calcPwmFromMinusSpeed)
+  {
+    SpeedCalculator speedCalc(-250.7);
+    int actualPwm = speedCalc.calcPwmFromSpeed();
+    EXPECT_GT(0, actualPwm);
+  }
+
+  TEST(SpeedCalculatorTest, calcPwmFromZeroSpeed)
+  {
+    SpeedCalculator speedCalc(0.0);
+    int actualPwm = speedCalc.calcPwmFromSpeed();
+    EXPECT_EQ(0, actualPwm);
+  }
+}  // namespace etrobocon2023_test

--- a/test/dummy/Motor.cpp
+++ b/test/dummy/Motor.cpp
@@ -16,11 +16,11 @@ Motor::Motor(ePortM _port, bool brake, motor_type_t type) : port(_port) {}
 int Motor::getCount()
 {
   if(port == PORT_C) {
-    return static_cast<int>(leftCount);
+    return static_cast<int>(motorCount);
   } else if(port == PORT_B) {
-    return static_cast<int>(rightCount);
+    return static_cast<int>(motorCount);
   } else {
-    return static_cast<int>(armCount);
+    return static_cast<int>(motorCount);
   }
 }
 
@@ -28,21 +28,18 @@ int Motor::getCount()
 void Motor::setPWM(int pwm)
 {
   if(port == PORT_C) {
-    leftCount += pwm * 0.05;
+    motorCount += pwm * 0.05;
   } else if(port == PORT_B) {
-    rightCount += pwm * 0.05;
+    motorCount += pwm * 0.05;
   } else {
-    armCount += pwm * 0.05;
+    motorCount += pwm * 0.05;
   }
 }
 
+// 　motorCountのリセット
 void Motor::reset()
 {
-  leftCount = 0;
-  rightCount = 0;
-  armCount = 0;
+  motorCount = 0;
 }
 
-double Motor::leftCount = 0.0;
-double Motor::rightCount = 0.0;
-double Motor::armCount = 0.0;
+double Motor::motorCount = 0.0;

--- a/test/dummy/Motor.cpp
+++ b/test/dummy/Motor.cpp
@@ -40,6 +40,7 @@ void Motor::reset()
 {
   leftCount = 0;
   rightCount = 0;
+  armCount = 0;
 }
 
 double Motor::leftCount = 0.0;

--- a/test/dummy/Motor.cpp
+++ b/test/dummy/Motor.cpp
@@ -1,7 +1,7 @@
 /**
  * @file Motor.cpp
  * @brief モータクラスで用いる関数（ダミー）
- * @author YKhm20020
+ * @author YKhm20020 miyashita64 bizyutyu
  */
 
 #include "Motor.h"

--- a/test/dummy/Motor.h
+++ b/test/dummy/Motor.h
@@ -44,9 +44,7 @@ namespace ev3api {
     void reset();
 
    private:
-    static double leftCount;
-    static double rightCount;
-    static double armCount;
+    static double motorCount;
     ePortM port;
   };
 }  // namespace ev3api

--- a/test/dummy/Motor.h
+++ b/test/dummy/Motor.h
@@ -1,7 +1,7 @@
 /**
  * @file Motor.h
  * @brief モータクラス（ダミー）
- * @author YKhm20020
+ * @author YKhm20020 miyashita64 bizyutyu
  */
 
 #ifndef MOTOR_H


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- SpeedCalculatorクラスの追加
- Controller内でMotorインスタンスのアドレスを保持するように変更

# 動作テスト
- Google Testにより、指定速度に相当するPWM値を算出する関数を呼び出せることを確認した
- 実機により、指定速度によって走行速度が変わることを確認した

## 実験データ
実験:速度300mm/sを指定し3秒間走行させた。(900mm進むと期待)
結果:隣のメジャーで780mm程度走行した。
考察:100mm程度の差は、斜めに進んだこととPIDで指定速度にするまでに若干のラグあることが原因だと思われる。

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/83441177/93857beb-d577-4657-b903-af8daad1c4af