### PR TITLE
close #12 CIでclang-formatが通らない件の調査

### DIFF
--- a/.github/workflows/google-test.yaml
+++ b/.github/workflows/google-test.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: test
-      run: ./gtest_all.sh
+      run: make gtest
 
     # 参考資料
     # - Slack が提供する GitHub Action "slack-send" を使って GitHub から Slack に通知する - Qiita

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ logfiles/
 # カメラシステムへのメッセージファイル
 scripts/message.txt
 
-# vsdode設定ファイル
+# vscode設定ファイル
 .vscode/settings.json
 
 # Created by https://www.toptal.com/developers/gitignore/api/c++,macos,windows

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ logfiles/
 # カメラシステムへのメッセージファイル
 scripts/message.txt
 
+# vsdode設定ファイル
+.vscode/settings.json
+
 # Created by https://www.toptal.com/developers/gitignore/api/c++,macos,windows
 # Edit at https://www.toptal.com/developers/gitignore?templates=c++,macos,windows
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,47 @@
-format:
-    git status -s | awk '{print $2}' | xargs clang-format -i -style=file
+MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+HOST = $(shell hostname)
 
-# make format_file FILE_NAME="sample.cpp"
-format_file:
-    clang-format -i -style=file $(FILE_NAME)
+# 使い方
+help:
+	@echo ビルドする
+	@echo " $$ make build"
+	@echo 走行を開始する\(実機限定\)
+	@echo " $$ make start"
+	@echo 指定ファイルをフォーマットする
+	@echo " $$ make format FILES=test/PidTest.cpp"
+	@echo すべての変更ファイルをフォーマットする
+	@echo " $$ make format"
+	@echo テストを実行する
+	@echo " $$ make gtest"
+
+# ビルドする
+build:
+# 実機で動かす場合(hostnameがkatlabから始まる場合)
+ifeq ($(filter katlab%,$(HOST)), $(HOST))
+	cd $(MAKEFILE_PATH)../ && make img=etrobocon2023
+# それ以外の環境の場合(開発環境など)
+else
+	cd $(ETROBO_ROOT) && make app=etrobocon2023
+endif
+
+# 実機の場合、走行を開始する 
+start:
+ifeq ($(filter katlab%,$(HOST)), $(HOST))
+	cd $(MAKEFILE_PATH)../ && make start
+endif
+
+# ファイルにclang-formatを適用する
+format:
+# 指定ファイルがある場合、そのファイルにclang-formatを適用する
+ifdef FILES
+	clang-format -i -style=file $(FILES)
+# ない場合、変更されたファイルのうち、cpp、hファイルにclang-formatを適用する
+else
+	git status -s | awk '/\.cpp$$|\.h$$/ {print $$2}' | xargs clang-format -i -style=file
+endif
+
+# テストを実行する
+# ※ターゲット名がtestだと動かない
+gtest:
+	set -eu
+	./test/gtest/gtest_build.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+format:
+    git status -s | awk '{print $2}' | xargs clang-format -i -style=file
+
+# make format_file FILE_NAME="sample.cpp"
+format_file:
+    clang-format -i -style=file $(FILE_NAME)

--- a/gtest_all.sh
+++ b/gtest_all.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -eu
-
-./test/gtest/gtest_build.sh

--- a/make.sh
+++ b/make.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-# etrobocon2023ディレクトリ下でもmakeできるようにする
-
-cd $ETROBO_ROOT
-make app=etrobocon2023 $@

--- a/test/PidTest.cpp
+++ b/test/PidTest.cpp
@@ -213,7 +213,7 @@ namespace etrobocon2023_test {
     double targetValue = 70;
     Pid actualPid(kp, ki, kd, targetValue);
     double currentValue = 60;
-    double currentDeviation = (targetValue - currentValue);
+    double currentDeviation = (targetValue - currentValue);                  // 現在の偏差
     double preDeviation = 0;
     double expected = ((preDeviation + currentDeviation) * DELTA / 2) * ki;  // I制御
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));

--- a/test/PidTest.cpp
+++ b/test/PidTest.cpp
@@ -213,7 +213,7 @@ namespace etrobocon2023_test {
     double targetValue = 70;
     Pid actualPid(kp, ki, kd, targetValue);
     double currentValue = 60;
-    double currentDeviation = (targetValue - currentValue);                  // 現在の偏差
+    double currentDeviation = (targetValue - currentValue);  // 現在の偏差
     double preDeviation = 0;
     double expected = ((preDeviation + currentDeviation) * DELTA / 2) * ki;  // I制御
     EXPECT_DOUBLE_EQ(expected, actualPid.calculatePid(currentValue));


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
通らなかったclang-formatはコマンドで行うことで、解決できた。
よって、build、start、format、gtestを行うMakefileを作成した。

## 使用方法

### ビルドする
```
$ make build"
```
### 走行を開始する\(実機限定\)
```
$ make start"
```

### 指定ファイルをフォーマットする
```
$ make format FILES=test/PidTest.cpp"
```
### すべての変更ファイルをフォーマットする
```
$ make format"
```
### テストを実行する
```
$ make gtest"
```

# 動作テスト
実機、ノートPCどちらも動作確認済み