### PR TITLE
Loggerのテストが通らない問題の解決(コード共有用)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 build/
 
 # ディレクトリ
-logfiles/
+logfiles/*
+!logfiles/.gitkeep
 
 # シミュレータ自動実行ツール関係
 .cancel-sim-test

--- a/test/gtest/gtest_build.sh
+++ b/test/gtest/gtest_build.sh
@@ -19,7 +19,7 @@ if [ -d $buildDir ]; then
     fi
 fi
 
-# NOTE: 実行とテストでカレントディレクトリが異なり，テストの際にファイルパスの指定ができないため，テスト用にdatafiles/及びscripts/ディレクトリを作成・コピーする
+# NOTE: 実行とテストでカレントディレクトリが異なり，テストの際にファイルパスの指定ができないため，テスト用にlogfiles/及びscripts/ディレクトリを作成・コピーする
 mkdir -p build
 mkdir -p build/etrobocon2023/logfiles
 mkdir -p build/etrobocon2023/scripts

--- a/test/gtest/gtest_build.sh
+++ b/test/gtest/gtest_build.sh
@@ -18,10 +18,19 @@ if [ -d $buildDir ]; then
         rm -rf build
     fi
 fi
+
+# NOTE: 実行とテストでカレントディレクトリが異なり，テストの際にファイルパスの指定ができないため，テスト用にdatafiles/及びscripts/ディレクトリを作成・コピーする
 mkdir -p build
+mkdir -p build/etrobocon2023/logfiles
+mkdir -p build/etrobocon2023/scripts
 cd build
+cp ../scripts/*.sh etrobocon2023/logfiles/
+cp ../scripts/*.sh etrobocon2023/scripts/
+chmod 777 ./etrobocon2023/scripts/*.sh
 
 cmake -DCMAKE_BUILD_TYPE=Coverage ..
 cmake --build .
 export GTEST_COLOR=1
 ctest -VV
+
+rm -rf etrobocon2023/


### PR DESCRIPTION
## 問題
Loggerをテストした際に、`scripts/`下のbashファイルが見つからず、テストが失敗する

## 原因
テスト環境は、`CMakeLists.txt`で定義したファイルやディレクトリをテスト環境(`build/`以下のどこか)にコピーしてテストを行っているが、`logfiles/`や`scripts/`をコピーしていなかった。

## 解決法
googletestを実行するスクリプト(`test/gtest/gtest_build.sh`)に、`logfiles/`や`scripts/`をコピーしテスト実行後に削除する処理を追加した。
(`CMakeLists.txt`等、cmake関連のファイルで対処できればよかったけど、cmake環境を理解しきれていないため、表面的な対処になりました)

参考: [KatLab/etrobocon2022のgtest_build.sh](https://github.com/KatLab-MiyazakiUniv/etrobocon2022/blob/main/test/gtest/gtest_build.sh)

## 追加の変更点
`logfiles/`下のファイルをgitの管理下に含めないために、`.gitignore`に記述があったが、ファイルが存在しないディレクトリはGitの管理下に置かれないため、`logfiles/`に`.gitkeep`を設置し、`.gitignore`で`.gitkeep`だけはGitの管理下に置くことで、`logfiles/`のディレクトリだけは管理下に含めている。