### PR TITLE
close #37 ライントレースの中間クラスを作成する

### DIFF
--- a/module/Motion/LineTracing.cpp
+++ b/module/Motion/LineTracing.cpp
@@ -18,8 +18,8 @@ LineTracing::LineTracing(double _targetSpeed, int _targetBrightness, const PidGa
 
 void LineTracing::run()
 {
-  int basePwm = 0;  // 初期PWM値 -100~100
-  int turnPwm = 0;  // 目標速度に対するpwm値を計算
+  basePwm = 0;      // 初期PWM値 -100~100
+  int turnPwm = 0;  // 目標速度に対するpwm値
   int edgeSign = 0;
   Pid pid(gain.kp, gain.ki, gain.kd, targetBrightness);
 

--- a/module/Motion/LineTracing.cpp
+++ b/module/Motion/LineTracing.cpp
@@ -7,7 +7,8 @@
 #include "LineTracing.h"
 using namespace std;
 
-LineTracing::LineTracing(double _targetDistance, int _targetBrightness, int _pwm, const PidGain& _gain, bool& _isLeftEdge)
+LineTracing::LineTracing(double _targetDistance, int _targetBrightness, int _pwm,
+                         const PidGain& _gain, bool& _isLeftEdge)
   : targetDistance(_targetDistance),
     targetBrightness(_targetBrightness),
     pwm(_pwm),
@@ -72,7 +73,8 @@ bool LineTracing::isMetPrecondition(int pwm, double targetDistance)
   return true;
 }
 
-bool LineTracing::isMetPostcondition(double initLeftMileage, double initRightMileage){
+bool LineTracing::isMetPostcondition(double initLeftMileage, double initRightMileage)
+{
   return false;
 }
 
@@ -85,7 +87,6 @@ void LineTracing::logRunning()
   snprintf(buf, BUF_SIZE,
            "Run LineTracing (targetDistance: %.2f, targetBrightness: %d, pwm: %d, gain: "
            "(%.2f,%.2f,%.2f), isLeftEdge: %s)",
-           targetDistance, targetBrightness, pwm, gain.kp, gain.ki, gain.kd,
-           str);
+           targetDistance, targetBrightness, pwm, gain.kp, gain.ki, gain.kd, str);
   logger.log(buf);
 }

--- a/module/Motion/LineTracing.cpp
+++ b/module/Motion/LineTracing.cpp
@@ -7,11 +7,10 @@
 #include "LineTracing.h"
 using namespace std;
 
-LineTracing::LineTracing(double _targetSpeed, int _targetBrightness, int _pwm, const PidGain& _gain,
+LineTracing::LineTracing(double _targetSpeed, int _targetBrightness, const PidGain& _gain,
                          bool& _isLeftEdge)
   : targetSpeed(_targetSpeed),
     targetBrightness(_targetBrightness),
-    pwm(_pwm),
     gain(_gain),
     isLeftEdge(_isLeftEdge)
 {
@@ -25,7 +24,7 @@ void LineTracing::run()
   Pid pid(gain.kp, gain.ki, gain.kd, targetBrightness);
 
   // 事前条件を判定する
-  if(!isMetPrecondition(pwm, targetSpeed)) {
+  if(!isMetPrecondition(basePwm, targetSpeed)) {
     return;
   }
 
@@ -38,11 +37,10 @@ void LineTracing::run()
 
   // 継続条件を満たしている間ループ
   while(isMetPostcondition()) {
-    // 目標速度に対するpwm値を計算
+    // 初期pwm値を計算
     SpeedCalculator SpeedCalculator(targetSpeed);
     basePwm = SpeedCalculator.calcPwmFromSpeed();
 
-    // PIDで旋回値を計算
     // 目標速度に対するpwm値を計算
     turnPwm = pid.calculatePid(Measurer::getBrightness()) * edgeSign;
 
@@ -51,10 +49,34 @@ void LineTracing::run()
     int leftPwm = basePwm > 0 ? max(basePwm + (int)turnPwm, 0) : min(basePwm - (int)turnPwm, 0);
     Controller::setRightMotorPwm(rightPwm);
     Controller::setLeftMotorPwm(leftPwm);
+
+    // 10ミリ秒待機
+    timer.sleep(10);
   }
 
   // モータの停止
   Controller::stopMotor();
+}
+
+bool LineTracing::isMetPrecondition(int basePwm, double targetSpeed)
+{
+  const int BUF_SIZE = 256;
+  char buf[BUF_SIZE];
+
+  // 初期pwm値が0の場合はwarningを出して終了する
+  if(basePwm == 0) {
+    logger.logWarning("The basePwm value passed to LineTracing is 0");
+    return false;
+  }
+
+  // targetSpeed値が0以下の場合はwarningを出して終了する
+  if(targetSpeed <= 0) {
+    snprintf(buf, BUF_SIZE, "The targetSpeed value passed to LineTracing is %lf", targetSpeed);
+    logger.logWarning(buf);
+    return false;
+  }
+
+  return true;
 }
 
 void LineTracing::logRunning()
@@ -63,9 +85,11 @@ void LineTracing::logRunning()
   char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
   const char* str = isLeftEdge ? "true" : "false";
 
+  // targetValueと%~のオーバーライド必須
   snprintf(buf, BUF_SIZE,
-           "Run LineTracing (targetSpeed: %.2f, targetBrightness: %d, pwm: %d, gain: "
+           "Run \"targetValue\" LineTracing (\"targetValue\": , targetSpeed: %.2f, "
+           "targetBrightness: %d, basePwm: %d, gain: "
            "(%.2f,%.2f,%.2f), isLeftEdge: %s)",
-           targetSpeed, targetBrightness, pwm, gain.kp, gain.ki, gain.kd, str);
+           targetSpeed, targetBrightness, basePwm, gain.kp, gain.ki, gain.kd, str);
   logger.log(buf);
 }

--- a/module/Motion/LineTracing.cpp
+++ b/module/Motion/LineTracing.cpp
@@ -19,7 +19,7 @@ LineTracing::LineTracing(double _targetSpeed, int _targetBrightness, const PidGa
 void LineTracing::run()
 {
   basePwm = 0;      // 初期PWM値 -100~100
-  int turnPwm = 0;  // 目標速度に対するpwm値
+  int turnPwm = 0;  // 旋回値を計算
   int edgeSign = 0;
   Pid pid(gain.kp, gain.ki, gain.kd, targetBrightness);
 
@@ -41,7 +41,7 @@ void LineTracing::run()
     SpeedCalculator SpeedCalculator(targetSpeed);
     basePwm = SpeedCalculator.calcPwmFromSpeed();
 
-    // 目標速度に対するpwm値を計算
+    // PIDで旋回値を計算
     turnPwm = pid.calculatePid(Measurer::getBrightness()) * edgeSign;
 
     // モータのPWM値をセット（0を超えないようにセット）

--- a/module/Motion/LineTracing.cpp
+++ b/module/Motion/LineTracing.cpp
@@ -1,0 +1,91 @@
+/**
+ * @file   LineTracing.cpp
+ * @brief  ライントレース動作の中間クラス
+ * @author YKhm20020
+ */
+
+#include "LineTracing.h"
+using namespace std;
+
+LineTracing::LineTracing(double _targetDistance, int _targetBrightness, int _pwm, const PidGain& _gain, bool& _isLeftEdge)
+  : targetDistance(_targetDistance),
+    targetBrightness(_targetBrightness),
+    pwm(_pwm),
+    gain(_gain),
+    isLeftEdge(_isLeftEdge)
+{
+}
+
+void LineTracing::run()
+{
+  int currentPid = 0;
+  int sign = 0;
+  Pid pid(gain.kp, gain.ki, gain.kd, targetBrightness);
+
+  // 事前条件を判定する
+  if(!isMetPrecondition(pwm, targetDistance)) {
+    return;
+  }
+
+  // 左右で符号を変える
+  sign = isLeftEdge ? -1 : 1;
+
+  // 呼び出し時の走行距離
+  initLeftMileage = Mileage::calculateWheelMileage(Measurer::getLeftCount());
+  initRightMileage = Mileage::calculateWheelMileage(Measurer::getRightCount());
+
+  // 継続条件を満たしている間ループ
+  while(isMetPostcondition(initLeftMileage, initRightMileage)) {
+    // PID計算
+    currentPid = pid.calculatePid(Measurer::getBrightness()) * sign;
+
+    // モータのPWM値をセット（0を超えないようにセット）
+    int rightPwm = pwm > 0 ? max(pwm - (int)currentPid, 0) : min(pwm + (int)currentPid, 0);
+    int leftPwm = pwm > 0 ? max(pwm + (int)currentPid, 0) : min(pwm - (int)currentPid, 0);
+    Controller::setRightMotorPwm(rightPwm);
+    Controller::setLeftMotorPwm(leftPwm);
+  }
+
+  // モータの停止
+  Controller::stopMotor();
+}
+
+bool LineTracing::isMetPrecondition(int pwm, double targetDistance)
+{
+  const int BUF_SIZE = 256;
+  char buf[BUF_SIZE];
+
+  // pwm値が0の場合はwarningを出して終了する
+  if(pwm == 0) {
+    logger.logWarning("The pwm value passed to LineTracing is 0");
+    return false;
+  }
+
+  // 目標距離が0以下の場合はwarningを出して終了する
+  if(targetDistance <= 0) {
+    snprintf(buf, BUF_SIZE, "The targetDistance value passed to LineTracing is %.2f",
+             targetDistance);
+    logger.logWarning(buf);
+    return false;
+  }
+
+  return true;
+}
+
+bool LineTracing::isMetPostcondition(double initLeftMileage, double initRightMileage){
+  return false;
+}
+
+void LineTracing::logRunning()
+{
+  const int BUF_SIZE = 256;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+  const char* str = isLeftEdge ? "true" : "false";
+
+  snprintf(buf, BUF_SIZE,
+           "Run LineTracing (targetDistance: %.2f, targetBrightness: %d, pwm: %d, gain: "
+           "(%.2f,%.2f,%.2f), isLeftEdge: %s)",
+           targetDistance, targetBrightness, pwm, gain.kp, gain.ki, gain.kd,
+           str);
+  logger.log(buf);
+}

--- a/module/Motion/LineTracing.cpp
+++ b/module/Motion/LineTracing.cpp
@@ -7,9 +7,9 @@
 #include "LineTracing.h"
 using namespace std;
 
-LineTracing::LineTracing(double _targetDistance, int _targetBrightness, int _pwm,
+LineTracing::LineTracing(double _targetSpeed, int _targetBrightness, int _pwm,
                          const PidGain& _gain, bool& _isLeftEdge)
-  : targetDistance(_targetDistance),
+  : targetSpeed(_targetSpeed),
     targetBrightness(_targetBrightness),
     pwm(_pwm),
     gain(_gain),
@@ -19,63 +19,42 @@ LineTracing::LineTracing(double _targetDistance, int _targetBrightness, int _pwm
 
 void LineTracing::run()
 {
-  int currentPid = 0;
-  int sign = 0;
+  int basePwm = 0;
+  int turnPwm = 0;
+  int edgeSign = 0;
   Pid pid(gain.kp, gain.ki, gain.kd, targetBrightness);
 
   // 事前条件を判定する
-  if(!isMetPrecondition(pwm, targetDistance)) {
+  if(!isMetPrecondition(pwm, targetSpeed)) {
     return;
   }
 
   // 左右で符号を変える
-  sign = isLeftEdge ? -1 : 1;
+  edgeSign = isLeftEdge ? -1 : 1;
 
   // 呼び出し時の走行距離
   initLeftMileage = Mileage::calculateWheelMileage(Measurer::getLeftCount());
   initRightMileage = Mileage::calculateWheelMileage(Measurer::getRightCount());
 
   // 継続条件を満たしている間ループ
-  while(isMetPostcondition(initLeftMileage, initRightMileage)) {
-    // PID計算
-    currentPid = pid.calculatePid(Measurer::getBrightness()) * sign;
+  while(isMetPostcondition()) {
+    // 目標速度に対するpwm値を計算
+    SpeedCalculator SpeedCalculator(targetSpeed);
+    basePwm = SpeedCalculator.calcPwmFromSpeed();
+
+    // PIDで旋回値を計算
+    // 目標速度に対するpwm値を計算
+    turnPwm = pid.calculatePid(Measurer::getBrightness()) * edgeSign;
 
     // モータのPWM値をセット（0を超えないようにセット）
-    int rightPwm = pwm > 0 ? max(pwm - (int)currentPid, 0) : min(pwm + (int)currentPid, 0);
-    int leftPwm = pwm > 0 ? max(pwm + (int)currentPid, 0) : min(pwm - (int)currentPid, 0);
+    int rightPwm = basePwm > 0 ? max(basePwm - (int)turnPwm, 0) : min(basePwm + (int)turnPwm, 0);
+    int leftPwm = basePwm > 0 ? max(basePwm + (int)turnPwm, 0) : min(basePwm - (int)turnPwm, 0);
     Controller::setRightMotorPwm(rightPwm);
     Controller::setLeftMotorPwm(leftPwm);
   }
 
   // モータの停止
   Controller::stopMotor();
-}
-
-bool LineTracing::isMetPrecondition(int pwm, double targetDistance)
-{
-  const int BUF_SIZE = 256;
-  char buf[BUF_SIZE];
-
-  // pwm値が0の場合はwarningを出して終了する
-  if(pwm == 0) {
-    logger.logWarning("The pwm value passed to LineTracing is 0");
-    return false;
-  }
-
-  // 目標距離が0以下の場合はwarningを出して終了する
-  if(targetDistance <= 0) {
-    snprintf(buf, BUF_SIZE, "The targetDistance value passed to LineTracing is %.2f",
-             targetDistance);
-    logger.logWarning(buf);
-    return false;
-  }
-
-  return true;
-}
-
-bool LineTracing::isMetPostcondition(double initLeftMileage, double initRightMileage)
-{
-  return false;
 }
 
 void LineTracing::logRunning()
@@ -85,8 +64,8 @@ void LineTracing::logRunning()
   const char* str = isLeftEdge ? "true" : "false";
 
   snprintf(buf, BUF_SIZE,
-           "Run LineTracing (targetDistance: %.2f, targetBrightness: %d, pwm: %d, gain: "
+           "Run LineTracing (targetSpeed: %.2f, targetBrightness: %d, pwm: %d, gain: "
            "(%.2f,%.2f,%.2f), isLeftEdge: %s)",
-           targetDistance, targetBrightness, pwm, gain.kp, gain.ki, gain.kd, str);
+           targetSpeed, targetBrightness, pwm, gain.kp, gain.ki, gain.kd, str);
   logger.log(buf);
 }

--- a/module/Motion/LineTracing.cpp
+++ b/module/Motion/LineTracing.cpp
@@ -8,7 +8,7 @@
 using namespace std;
 
 LineTracing::LineTracing(double _targetSpeed, int _targetBrightness, const PidGain& _gain,
-                         bool& _isLeftEdge)
+                         bool _isLeftEdge)
   : targetSpeed(_targetSpeed),
     targetBrightness(_targetBrightness),
     gain(_gain),

--- a/module/Motion/LineTracing.cpp
+++ b/module/Motion/LineTracing.cpp
@@ -7,8 +7,8 @@
 #include "LineTracing.h"
 using namespace std;
 
-LineTracing::LineTracing(double _targetSpeed, int _targetBrightness, int _pwm,
-                         const PidGain& _gain, bool& _isLeftEdge)
+LineTracing::LineTracing(double _targetSpeed, int _targetBrightness, int _pwm, const PidGain& _gain,
+                         bool& _isLeftEdge)
   : targetSpeed(_targetSpeed),
     targetBrightness(_targetBrightness),
     pwm(_pwm),

--- a/module/Motion/LineTracing.cpp
+++ b/module/Motion/LineTracing.cpp
@@ -18,8 +18,8 @@ LineTracing::LineTracing(double _targetSpeed, int _targetBrightness, const PidGa
 
 void LineTracing::run()
 {
-  int basePwm = 0;
-  int turnPwm = 0;
+  int basePwm = 0;  // 初期PWM値 -100~100
+  int turnPwm = 0;  // 目標速度に対するpwm値を計算
   int edgeSign = 0;
   Pid pid(gain.kp, gain.ki, gain.kd, targetBrightness);
 

--- a/module/Motion/LineTracing.h
+++ b/module/Motion/LineTracing.h
@@ -10,18 +10,19 @@
 #include "Motion.h"
 #include "Mileage.h"
 #include "Pid.h"
+#include "SpeedCalculator.h"
 
 class LineTracing : public Motion {
  public:
   /**
    * コンストラクタ
-   * @param _targetDistance 目標距離 0~
+   * @param _targetSpeed 目標速度 0~
    * @param _targetBrightness 目標輝度 0~
    * @param _pwm PWM値 -100~100
    * @param _gain PIDゲイン
    * @param _isLeftEdge エッジの左右判定(true:左エッジ, false:右エッジ)
    */
-  LineTracing(double _targetDistance, int _targetBrightness, int _pwm, const PidGain& _gain,
+  LineTracing(double _targetSpeed, int _targetBrightness, int _pwm, const PidGain& _gain,
               bool& _isLeftEdge);
 
   /**
@@ -32,18 +33,16 @@ class LineTracing : public Motion {
   /**
    * @brief ライントレースする際の事前条件判定をする
    * @param pwm PWM値
-   * @param targetDistance 目標距離
+   * @param targetSpeed 目標速度
    * @note オーバーライド必須
    */
-  virtual bool isMetPrecondition(int pwm, double targetDistance) = 0;
+  virtual bool isMetPrecondition(int pwm, double targetSpeed) = 0;
 
   /**
    * @brief ライントレースする際の継続条件判定をする　返り値がfalseでモーターが止まる
-   * @param initLeftMileage   ライントレースを始めた時点での左車輪の走行距離
-   * @param initRightMileage  ライントレースを始めた時点での右車輪の走行距離
    * @note オーバーライド必須
    */
-  virtual bool isMetPostcondition(double initLeftMileage, double initRightMileage) = 0;
+  virtual bool isMetPostcondition() = 0;
 
   /**
    * @brief 実行のログを取る
@@ -51,7 +50,7 @@ class LineTracing : public Motion {
   void logRunning();
 
  private:
-  double targetDistance;    // 目標距離 0~
+  double targetSpeed;       // 目標速度 0~
   int targetBrightness;     // 目標輝度 0~
   int pwm;                  // PWM値 -100~100
   PidGain gain;             // PIDゲイン

--- a/module/Motion/LineTracing.h
+++ b/module/Motion/LineTracing.h
@@ -1,0 +1,62 @@
+/**
+ * @file   LineTracing.h
+ * @brief  ライントレース動作
+ * @author YKhm20020
+ */
+
+#ifndef LINE_TRACING_H
+#define LINE_TRACING_H
+
+#include "Motion.h"
+#include "Mileage.h"
+#include "Pid.h"
+
+class LineTracing : public Motion {
+ public:
+  /**
+   * コンストラクタ
+   * @param _targetDistance 目標距離 0~
+   * @param _targetBrightness 目標輝度 0~
+   * @param _pwm PWM値 -100~100
+   * @param _gain PIDゲイン
+   * @param _isLeftEdge エッジの左右判定(true:左エッジ, false:右エッジ)
+   */
+  LineTracing(double _targetDistance, int _targetBrightness, int _pwm, const PidGain& _gain, bool& _isLeftEdge);
+
+  /**
+   * @brief ライントレースする
+   */
+  void run();
+
+  /**
+   * @brief ライントレースする際の事前条件判定をする
+   * @param pwm PWM値
+   * @param targetDistance 目標距離
+   * @note オーバーライド必須
+   */
+  virtual bool isMetPrecondition(int pwm, double targetDistance) = 0;
+
+  /**
+   * @brief ライントレースする際の継続条件判定をする　返り値がfalseでモーターが止まる
+   * @param initLeftMileage   ライントレースを始めた時点での左車輪の走行距離
+   * @param initRightMileage  ライントレースを始めた時点での右車輪の走行距離
+   * @note オーバーライド必須
+   */
+  virtual bool isMetPostcondition(double initLeftMileage, double initRightMileage) = 0;
+
+  /**
+   * @brief 実行のログを取る
+   */
+  void logRunning();
+
+  private:
+    double targetDistance;// 目標距離 0~
+    int targetBrightness; // 目標輝度 0~
+    int pwm;  // PWM値 -100~100
+    PidGain gain;  // PIDゲイン
+    bool& isLeftEdge;  // エッジの左右判定(true:左エッジ, false:右エッジ)
+    double initLeftMileage;   // クラス呼び出し時の左車輪の走行距離
+    double initRightMileage;  // クラス呼び出し時の右車輪の走行距離
+};
+
+#endif

--- a/module/Motion/LineTracing.h
+++ b/module/Motion/LineTracing.h
@@ -21,7 +21,7 @@ class LineTracing : public Motion {
    * @param _gain PIDゲイン
    * @param _isLeftEdge エッジの左右判定(true:左エッジ, false:右エッジ)
    */
-  LineTracing(double _targetSpeed, int _targetBrightness, const PidGain& _gain, bool& _isLeftEdge);
+  LineTracing(double _targetSpeed, int _targetBrightness, const PidGain& _gain, bool _isLeftEdge);
 
   /**
    * @brief ライントレースする
@@ -52,7 +52,7 @@ class LineTracing : public Motion {
   int targetBrightness;     // 目標輝度 0~
   int basePwm;              // 初期PWM値 -100~100
   PidGain gain;             // PIDゲイン
-  bool& isLeftEdge;         // エッジの左右判定(true:左エッジ, false:右エッジ)
+  bool isLeftEdge;          // エッジの左右判定(true:左エッジ, false:右エッジ)
   double initLeftMileage;   // クラス呼び出し時の左車輪の走行距離
   double initRightMileage;  // クラス呼び出し時の右車輪の走行距離
   class Timer timer;

--- a/module/Motion/LineTracing.h
+++ b/module/Motion/LineTracing.h
@@ -45,7 +45,7 @@ class LineTracing : public Motion {
   /**
    * @brief 実行のログを取る
    */
-  void logRunning();
+  virtual void logRunning();
 
  private:
   double targetSpeed;       // 目標速度 0~

--- a/module/Motion/LineTracing.h
+++ b/module/Motion/LineTracing.h
@@ -50,12 +50,11 @@ class LineTracing : public Motion {
  private:
   double targetSpeed;    // 目標速度 0~
   int targetBrightness;  // 目標輝度 0~
-  int basePwm;           // 初期PWM値 -100~100
   PidGain gain;          // PIDゲイン
-  class Timer timer;
   bool& isLeftEdge;         // エッジの左右判定(true:左エッジ, false:右エッジ)
   double initLeftMileage;   // クラス呼び出し時の左車輪の走行距離
   double initRightMileage;  // クラス呼び出し時の右車輪の走行距離
+  class Timer timer;
 };
 
 #endif

--- a/module/Motion/LineTracing.h
+++ b/module/Motion/LineTracing.h
@@ -21,7 +21,8 @@ class LineTracing : public Motion {
    * @param _gain PIDゲイン
    * @param _isLeftEdge エッジの左右判定(true:左エッジ, false:右エッジ)
    */
-  LineTracing(double _targetDistance, int _targetBrightness, int _pwm, const PidGain& _gain, bool& _isLeftEdge);
+  LineTracing(double _targetDistance, int _targetBrightness, int _pwm, const PidGain& _gain,
+              bool& _isLeftEdge);
 
   /**
    * @brief ライントレースする
@@ -49,14 +50,14 @@ class LineTracing : public Motion {
    */
   void logRunning();
 
-  private:
-    double targetDistance;// 目標距離 0~
-    int targetBrightness; // 目標輝度 0~
-    int pwm;  // PWM値 -100~100
-    PidGain gain;  // PIDゲイン
-    bool& isLeftEdge;  // エッジの左右判定(true:左エッジ, false:右エッジ)
-    double initLeftMileage;   // クラス呼び出し時の左車輪の走行距離
-    double initRightMileage;  // クラス呼び出し時の右車輪の走行距離
+ private:
+  double targetDistance;    // 目標距離 0~
+  int targetBrightness;     // 目標輝度 0~
+  int pwm;                  // PWM値 -100~100
+  PidGain gain;             // PIDゲイン
+  bool& isLeftEdge;         // エッジの左右判定(true:左エッジ, false:右エッジ)
+  double initLeftMileage;   // クラス呼び出し時の左車輪の走行距離
+  double initRightMileage;  // クラス呼び出し時の右車輪の走行距離
 };
 
 #endif

--- a/module/Motion/LineTracing.h
+++ b/module/Motion/LineTracing.h
@@ -48,9 +48,10 @@ class LineTracing : public Motion {
   void logRunning();
 
  private:
-  double targetSpeed;    // 目標速度 0~
-  int targetBrightness;  // 目標輝度 0~
-  PidGain gain;          // PIDゲイン
+  double targetSpeed;       // 目標速度 0~
+  int targetBrightness;     // 目標輝度 0~
+  int basePwm;              // 初期PWM値 -100~100
+  PidGain gain;             // PIDゲイン
   bool& isLeftEdge;         // エッジの左右判定(true:左エッジ, false:右エッジ)
   double initLeftMileage;   // クラス呼び出し時の左車輪の走行距離
   double initRightMileage;  // クラス呼び出し時の右車輪の走行距離

--- a/module/Motion/LineTracing.h
+++ b/module/Motion/LineTracing.h
@@ -18,12 +18,10 @@ class LineTracing : public Motion {
    * コンストラクタ
    * @param _targetSpeed 目標速度 0~
    * @param _targetBrightness 目標輝度 0~
-   * @param _pwm PWM値 -100~100
    * @param _gain PIDゲイン
    * @param _isLeftEdge エッジの左右判定(true:左エッジ, false:右エッジ)
    */
-  LineTracing(double _targetSpeed, int _targetBrightness, int _pwm, const PidGain& _gain,
-              bool& _isLeftEdge);
+  LineTracing(double _targetSpeed, int _targetBrightness, const PidGain& _gain, bool& _isLeftEdge);
 
   /**
    * @brief ライントレースする
@@ -32,11 +30,11 @@ class LineTracing : public Motion {
 
   /**
    * @brief ライントレースする際の事前条件判定をする
-   * @param pwm PWM値
+   * @param basePwm 初期PWM値
    * @param targetSpeed 目標速度
    * @note オーバーライド必須
    */
-  virtual bool isMetPrecondition(int pwm, double targetSpeed) = 0;
+  bool isMetPrecondition(int basePwm, double targetSpeed);
 
   /**
    * @brief ライントレースする際の継続条件判定をする　返り値がfalseでモーターが止まる
@@ -50,10 +48,11 @@ class LineTracing : public Motion {
   void logRunning();
 
  private:
-  double targetSpeed;       // 目標速度 0~
-  int targetBrightness;     // 目標輝度 0~
-  int pwm;                  // PWM値 -100~100
-  PidGain gain;             // PIDゲイン
+  double targetSpeed;    // 目標速度 0~
+  int targetBrightness;  // 目標輝度 0~
+  int basePwm;           // 初期PWM値 -100~100
+  PidGain gain;          // PIDゲイン
+  class Timer timer;
   bool& isLeftEdge;         // エッジの左右判定(true:左エッジ, false:右エッジ)
   double initLeftMileage;   // クラス呼び出し時の左車輪の走行距離
   double initRightMileage;  // クラス呼び出し時の右車輪の走行距離


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
module/Motion 下に以下のファイルを追加。
- LineTracing.h
- LineTracing.cpp

[イテレーション中に同じ変更を含む場合の対処](https://github.com/KatLab-MiyazakiUniv/etrobocon2023/wiki/%E3%82%A4%E3%83%86%E3%83%AC%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E4%B8%AD%E3%81%AB%E5%90%8C%E3%81%98%E5%A4%89%E6%9B%B4%E3%82%92%E5%90%AB%E3%82%80%E5%A0%B4%E5%90%88%E3%81%AE%E5%AF%BE%E5%87%A6)で取り込んだところ、もとのブランチが消えたのでプルリク上げ直しています。正しく手順通りにできていれば作業内容は消えていないはずです。僕のは消えませんでした。宮下さんありがとうございます🙇

追記：
プルリク消えた件はブランチ移動を忘れたせいかもしれないです。申し訳ありません🙇

あと、ヘッダファイルの仮想関数化についてなのですが、virtual をそもそもつけるかと、つける場合はvirtualを記述したあとに = 0 をつけるときとつけないときの違いがあるか、それによって挙動が変わったりするのかがわかっていません。
根木原君によると、関数の中身（引数ではなく実際のコード）がある場合は virtual と = 0 をつけるみたいです。

# 動作テスト
子クラス実装でライントレース関係全体の Test を作成します。今のところコンパイルエラーは起きていないことだけ確認できています。
