### PR TITLE
close #48 テストでモータカウントを保持する

### DIFF
--- a/module/API/Controller.h
+++ b/module/API/Controller.h
@@ -11,9 +11,6 @@
 
 class Controller {
  public:
-  static const ePortM rightWheelPort = PORT_B;
-  static const ePortM leftWheelPort = PORT_C;
-  static const ePortM armMotorPort = PORT_A;
   static ev3api::Motor* rightMotor;
   static ev3api::Motor* leftMotor;
   static ev3api::Motor* armMotor;

--- a/module/API/Measurer.cpp
+++ b/module/API/Measurer.cpp
@@ -1,10 +1,16 @@
 /**
  * @file Measurer.cpp
  * @brief 計測に用いる関数をまとめたラッパークラス
- * @author YKhm20020
+ * @author YKhm20020 miyashita64
  */
 
 #include "Measurer.h"
+
+ev3api::ColorSensor* Measurer::colorSensor = nullptr;
+ev3api::SonarSensor* Measurer::sonarSensor = nullptr;
+ev3api::Motor* Measurer::rightMotor = nullptr;
+ev3api::Motor* Measurer::leftMotor = nullptr;
+ev3api::Motor* Measurer::armMotor = nullptr;
 
 // 明るさを取得
 // 参考: https://tomari.org/main/java/color/ccal.html
@@ -21,26 +27,26 @@ int Measurer::getBrightness()
 rgb_raw_t Measurer::getRawColor()
 {
   rgb_raw_t rgb;
-  ev3api::ColorSensor(colorSensorPort).getRawColor(rgb);
+  colorSensor->getRawColor(rgb);
   return rgb;
 }
 
 // 左モータ角位置取得
 int Measurer::getLeftCount()
 {
-  return ev3api::Motor(leftWheelPort).getCount();
+  return leftMotor->getCount();
 }
 
 // 右モータ角位置取得
 int Measurer::getRightCount()
 {
-  return ev3api::Motor(rightWheelPort).getCount();
+  return rightMotor->getCount();
 }
 
 // アームモータ角位置取得
 int Measurer::getArmMotorCount()
 {
-  return ev3api::Motor(armMotorPort).getCount();
+  return armMotor->getCount();
 }
 
 // 正面から見て左ボタンの押下状態を取得
@@ -64,7 +70,7 @@ bool Measurer::getEnterButton()
 // 超音波センサからの距離を取得
 int Measurer::getForwardDistance()
 {
-  int distance = ev3api::SonarSensor(sonarSensorPort).getDistance();
+  int distance = sonarSensor->getDistance();
 
   // センサが認識していない時が-1になる
   if(distance == -1) distance = 1000;

--- a/module/API/Measurer.h
+++ b/module/API/Measurer.h
@@ -1,7 +1,7 @@
 /**
  * @file Measurer.h
  * @brief 計測に用いる関数をまとめたラッパークラス
- * @author YKhm20020
+ * @author YKhm20020 miyashita64
  */
 
 #ifndef MEASURER_H
@@ -15,6 +15,12 @@
 
 class Measurer {
  public:
+  static ev3api::ColorSensor* colorSensor;
+  static ev3api::SonarSensor* sonarSensor;
+  static ev3api::Motor* rightMotor;
+  static ev3api::Motor* leftMotor;
+  static ev3api::Motor* armMotor;
+
   Measurer() = delete;  // 明示的にインスタンス化を禁止
 
   /**
@@ -77,13 +83,6 @@ class Measurer {
    * @return SPIKEの電圧[V]
    */
   static double getVoltage();
-
- private:
-  static const ePortS colorSensorPort = PORT_2;
-  static const ePortS sonarSensorPort = PORT_3;
-  static const ePortM leftWheelPort = PORT_C;
-  static const ePortM rightWheelPort = PORT_B;
-  static const ePortM armMotorPort = PORT_A;
 };
 
 #endif

--- a/module/EtRobocon2023.cpp
+++ b/module/EtRobocon2023.cpp
@@ -7,15 +7,32 @@
 #include "EtRobocon2023.h"
 // ev3api.hをインクルードしているものは.cppに書く
 #include "ev3api.h"
+#include "ColorSensor.h"
+#include "SonarSensor.h"
 #include "Motor.h"
 #include "Controller.h"
+#include "Measurer.h"
 
 void EtRobocon2023::start()
 {
-  ev3api::Motor _rightWheel(Controller::rightWheelPort);
-  ev3api::Motor _leftWheel(Controller::leftWheelPort);
-  ev3api::Motor _armMotor(Controller::armMotorPort);
-  Controller::rightMotor = &_rightWheel;
-  Controller::leftMotor = &_leftWheel;
+  const ePortS colorSensorPort = PORT_2;
+  const ePortS sonarSensorPort = PORT_3;
+  const ePortM armMotorPort = PORT_A;
+  const ePortM rightMotorPort = PORT_B;
+  const ePortM leftMotorPort = PORT_C;
+
+  ev3api::ColorSensor _colorSensor(PORT_2);
+  ev3api::SonarSensor _sonarSensor(PORT_3);
+  ev3api::Motor _rightMotor(rightMotorPort);
+  ev3api::Motor _leftMotor(leftMotorPort);
+  ev3api::Motor _armMotor(armMotorPort);
+
+  Controller::rightMotor = &_rightMotor;
+  Controller::leftMotor = &_leftMotor;
   Controller::armMotor = &_armMotor;
+  Measurer::colorSensor = &_colorSensor;
+  Measurer::sonarSensor = &_sonarSensor;
+  Measurer::rightMotor = &_rightMotor;
+  Measurer::leftMotor = &_leftMotor;
+  Measurer::armMotor = &_armMotor;
 }

--- a/module/EtRobocon2023.cpp
+++ b/module/EtRobocon2023.cpp
@@ -21,8 +21,8 @@ void EtRobocon2023::start()
   const ePortM rightMotorPort = PORT_B;
   const ePortM leftMotorPort = PORT_C;
 
-  ev3api::ColorSensor _colorSensor(PORT_2);
-  ev3api::SonarSensor _sonarSensor(PORT_3);
+  ev3api::ColorSensor _colorSensor(colorSensorPort);
+  ev3api::SonarSensor _sonarSensor(sonarSensorPort);
   ev3api::Motor _rightMotor(rightMotorPort);
   ev3api::Motor _leftMotor(leftMotorPort);
   ev3api::Motor _armMotor(armMotorPort);

--- a/test/000_GTestInit.cpp
+++ b/test/000_GTestInit.cpp
@@ -23,8 +23,8 @@ namespace etrobocon2023_test {
     const ePortM rightMotorPort = PORT_B;
     const ePortM leftMotorPort = PORT_C;
 
-    ev3api::ColorSensor _colorSensor(PORT_2);
-    ev3api::SonarSensor _sonarSensor(PORT_3);
+    ev3api::ColorSensor _colorSensor(colorSensorPort);
+    ev3api::SonarSensor _sonarSensor(sonarSensorPort);
     ev3api::Motor _rightMotor(rightMotorPort);
     ev3api::Motor _leftMotor(leftMotorPort);
     ev3api::Motor _armMotor(armMotorPort);

--- a/test/000_GTestInit.cpp
+++ b/test/000_GTestInit.cpp
@@ -1,0 +1,43 @@
+/**
+ * @file 000_GTestInit.cpp
+ * @brief GoogleTest時に必要な初期化処理を行う
+ * @author miyashita64
+ */
+
+#include "ColorSensor.h"
+#include "SonarSensor.h"
+#include "Motor.h"
+#include "Controller.h"
+#include "Measurer.h"
+#include <gtest/gtest.h>
+
+using namespace std;
+
+namespace etrobocon2023_test {
+
+  TEST(GTestInit, init)
+  {
+    const ePortS colorSensorPort = PORT_2;
+    const ePortS sonarSensorPort = PORT_3;
+    const ePortM armMotorPort = PORT_A;
+    const ePortM rightMotorPort = PORT_B;
+    const ePortM leftMotorPort = PORT_C;
+
+    ev3api::ColorSensor _colorSensor(PORT_2);
+    ev3api::SonarSensor _sonarSensor(PORT_3);
+    ev3api::Motor _rightMotor(rightMotorPort);
+    ev3api::Motor _leftMotor(leftMotorPort);
+    ev3api::Motor _armMotor(armMotorPort);
+
+    Controller::rightMotor = &_rightMotor;
+    Controller::leftMotor = &_leftMotor;
+    Controller::armMotor = &_armMotor;
+    Measurer::colorSensor = &_colorSensor;
+    Measurer::sonarSensor = &_sonarSensor;
+    Measurer::rightMotor = &_rightMotor;
+    Measurer::leftMotor = &_leftMotor;
+    Measurer::armMotor = &_armMotor;
+
+    SUCCEED();
+  }
+}  // namespace etrobocon2023_test

--- a/test/ControllerTest.cpp
+++ b/test/ControllerTest.cpp
@@ -6,29 +6,44 @@
 
 #include "ev3api.h"
 #include "Controller.h"
+#include "Measurer.h"
 #include <gtest/gtest.h>
 
 namespace etrobocon2023_test {
   TEST(ControllerTest, setRightMotorPwm)
   {
     const int pwm = 50;
-    ev3api::Motor _rightWheel(Controller::rightWheelPort);
-    ev3api::Motor _leftWheel(Controller::leftWheelPort);
-    ev3api::Motor _armMotor(Controller::armMotorPort);
-    Controller::rightMotor = &_rightWheel;
-    Controller::leftMotor = &_leftWheel;
-    Controller::armMotor = &_armMotor;
+    int initCount = Measurer::getRightCount();
     Controller::setRightMotorPwm(pwm);
-    Controller::rightMotor->reset();
-    SUCCEED();
+    int currentCount = Measurer::getRightCount();
+    EXPECT_LT(initCount, currentCount);
+  }
+
+  TEST(ControllerTest, setRightMotorMinusPwm)
+  {
+    const int pwm = -30;
+    int initCount = Measurer::getRightCount();
+    Controller::setRightMotorPwm(pwm);
+    int currentCount = Measurer::getRightCount();
+    EXPECT_GT(initCount, currentCount);
   }
 
   TEST(ControllerTest, setLeftMotorPwm)
   {
     const int pwm = 50;
+    int initCount = Measurer::getLeftCount();
     Controller::setLeftMotorPwm(pwm);
-    Controller::leftMotor->reset();
-    SUCCEED();
+    int currentCount = Measurer::getLeftCount();
+    EXPECT_LT(initCount, currentCount);
+  }
+
+  TEST(ControllerTest, setLeftMotorMinusPwm)
+  {
+    const int pwm = -150;
+    int initCount = Measurer::getLeftCount();
+    Controller::setLeftMotorPwm(pwm);
+    int currentCount = Measurer::getLeftCount();
+    EXPECT_GT(initCount, currentCount);
   }
 
   TEST(ControllerTest, stopMotor)
@@ -40,9 +55,10 @@ namespace etrobocon2023_test {
   TEST(ControllerTest, setArmMotorPwm)
   {
     const int pwm = 50;
+    int initCount = Measurer::getArmMotorCount();
     Controller::setArmMotorPwm(pwm);
-    Controller::armMotor->reset();
-    SUCCEED();
+    int currentCount = Measurer::getArmMotorCount();
+    EXPECT_LT(initCount, currentCount);
   }
 
   TEST(ControllerTest, stopArmMotor)

--- a/test/dummy/Motor.cpp
+++ b/test/dummy/Motor.cpp
@@ -8,38 +8,27 @@
 using namespace ev3api;
 
 // コンストラクタ
-Motor::Motor(ePortM _port, bool brake, motor_type_t type) : port(_port) {}
+Motor::Motor(ePortM _port, bool brake, motor_type_t type)
+{
+  motorCount = 0;
+}
 
 // PORT_B　右モータ
 // PORT_C　左モータ
 // モータ角位置取得
 int Motor::getCount()
 {
-  if(port == PORT_C) {
-    return static_cast<int>(motorCount);
-  } else if(port == PORT_B) {
-    return static_cast<int>(motorCount);
-  } else {
-    return static_cast<int>(motorCount);
-  }
+  return static_cast<int>(motorCount);
 }
 
 // pwm値設定
 void Motor::setPWM(int pwm)
 {
-  if(port == PORT_C) {
-    motorCount += pwm * 0.05;
-  } else if(port == PORT_B) {
-    motorCount += pwm * 0.05;
-  } else {
-    motorCount += pwm * 0.05;
-  }
+  motorCount += pwm * 0.05;
 }
 
-// 　motorCountのリセット
+// motorCountのリセット
 void Motor::reset()
 {
   motorCount = 0;
 }
-
-double Motor::motorCount = 0.0;

--- a/test/dummy/Motor.h
+++ b/test/dummy/Motor.h
@@ -41,11 +41,13 @@ namespace ev3api {
      */
     void stop(){};
 
+    /**
+     * モータカウントを初期化する
+     */
     void reset();
 
    private:
-    static double motorCount;
-    ePortM port;
+    double motorCount;
   };
 }  // namespace ev3api
 

--- a/test/dummy/SonarSensor.cpp
+++ b/test/dummy/SonarSensor.cpp
@@ -8,10 +8,11 @@
 using namespace ev3api;
 
 // コンストラクタ
-SonarSensor::SonarSensor(ePortS port) : distance(3) {}
+SonarSensor::SonarSensor(ePortS port) : distance(20) {}
 
 // センサーまでの距離を取得
 int SonarSensor::getDistance()
 {
+  distance = (distance > 0) ? distance - 1 : 20;
   return distance;
 }


### PR DESCRIPTION
# チェックリスト
- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- Measurer内のMotorとSensorのインスタンス化を削除しメンバとしてポインタを保持するよう変更
- Etrobocon2023でMotorとSensorをインスタンス化し、Measurerのメンバを更新する処理を追加
- 変更に伴うdummyやテストケースの調整

# 動作テスト

## 実験方法
各モータについて、Controllerでpwmを設定し、その前後でMeasurerにより取得するモータカウントが変化していることを確認した。(実装前は、モータカウントを取得するたびにMotorをインスタンス化していたため、MotorインスタンスがmotorCountを保持できなかった)

