### PR TITLE
close #43 ライントレースの子クラス作成

### DIFF
--- a/module/Motion/ColorLineTracing.cpp
+++ b/module/Motion/ColorLineTracing.cpp
@@ -1,0 +1,65 @@
+/**
+ * @file   ColorLineTracing.cpp
+ * @brief  指定色ライントレース動作
+ * @author YKhm20020
+ */
+
+#include "ColorLineTracing.h"
+
+using namespace std;
+
+ColorLineTracing::ColorLineTracing(COLOR _targetColor, double _targetSpeed, int _targetBrightness,
+                                   const PidGain& _gain, bool& _isLeftEdge)
+  : LineTracing(_targetSpeed, _targetBrightness, _gain, _isLeftEdge), targetColor(_targetColor){};
+
+bool ColorLineTracing::isMetPrecondition(double targetSpeed)
+{
+  const int BUF_SIZE = 256;
+  char buf[BUF_SIZE];
+
+  // targetSpeed値が0の場合はwarningを出して終了する
+  if(targetSpeed == 0.0) {
+    snprintf(buf, BUF_SIZE, "The targetSpeed value passed to ColorLineTracing is 0");
+    logger.logWarning(buf);
+    return false;
+  }
+
+  // 目標の色がNoneのときwarningを出して終了する
+  if(targetColor == COLOR::NONE) {
+    logger.logWarning("The targetColor passed to ColorLineTracing is NONE");
+    return false;
+  }
+
+  return true;
+}
+
+bool ColorLineTracing::isMetPostcondition()
+{
+  COLOR currentColor = COLOR::NONE;
+
+  currentColor = ColorJudge::getColor(Measurer::getRawColor());
+  if(currentColor == targetColor) {
+    colorCount++;
+  } else {
+    colorCount = 0;
+  }
+  // 指定された色をJUDGE_COUNT回連続で取得
+  if(colorCount >= JUDGE_COUNT) return false;
+
+  return true;
+}
+
+void ColorLineTracing::logRunning()
+{
+  const int BUF_SIZE = 256;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+  const char* str = isLeftEdge ? "true" : "false";
+
+  snprintf(buf, BUF_SIZE,
+           "Run ColorLineTracing (targetColor: %s, targetSpeed: %.2f, targetBrightness: %d, pwm: "
+           "%d, gain: "
+           "(%.2f,%.2f,%.2f), isLeftEdge: %s)",
+           ColorJudge::colorToString(targetColor), targetSpeed, targetBrightness, basePwm, gain.kp,
+           gain.ki, gain.kd, str);
+  logger.log(buf);
+}

--- a/module/Motion/ColorLineTracing.h
+++ b/module/Motion/ColorLineTracing.h
@@ -1,0 +1,56 @@
+/**
+ * @file   ColorLineTracing.h
+ * @brief  指定色ライントレース動作
+ * @author YKhm20020
+ */
+
+#ifndef COLOR_LINE_TRACING_H
+#define COLOR_LINE_TRACING_H
+
+#include "LineTracing.h"
+#include "ColorJudge.h"
+
+class ColorLineTracing : public LineTracing {
+ public:
+  /**
+   * コンストラクタ
+   * @param _targetColor 指定色
+   * @param _targetSpeed 目標速度
+   * @param _targetBrightness 目標輝度 0~
+   * @param _gain PIDゲイン
+   * @param _isLeftEdge エッジの左右判定(true:左エッジ, false:右エッジ)
+   */
+  ColorLineTracing(COLOR _targetColor, double _targetSpeed, int _targetBrightness,
+                   const PidGain& _gain, bool& _isLeftEdge);
+
+  /**
+   * @brief 指定色までライントレースする
+   */
+  using LineTracing::run;
+
+  /**
+   * @brief 指定色ライントレースする際の事前条件判定をする
+   * @param targetSpeed 目標速度
+   * @note オーバーライド必須
+   */
+  bool isMetPrecondition(double targetSpeed) override;
+
+  /**
+   * @brief 指定色ライントレースする際の継続条件判定をする　返り値がfalseでモーターが止まる
+   * @note オーバーライド必須
+   */
+  bool isMetPostcondition() override;
+
+  /**
+   * @brief 実行のログを取る
+   * @note オーバーライド必須
+   */
+  void logRunning() override;
+
+ private:
+  static constexpr int JUDGE_COUNT = 3;
+  int colorCount = 0;
+  COLOR targetColor;  // 指定色
+};
+
+#endif

--- a/module/Motion/DistanceLineTracing.cpp
+++ b/module/Motion/DistanceLineTracing.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file   DistanceLineTracing.cpp
+ * @brief  指定距離ライントレース動作
+ * @author YKhm20020
+ */
+
+#include "DistanceLineTracing.h"
+using namespace std;
+
+DistanceLineTracing::DistanceLineTracing(double _targetDistance, double _targetSpeed,
+                                         int _targetBrightness, const PidGain& _gain,
+                                         bool& _isLeftEdge)
+  : LineTracing(_targetSpeed, _targetBrightness, _gain, _isLeftEdge),
+    targetDistance(_targetDistance){};
+
+bool DistanceLineTracing::isMetPrecondition(double targetSpeed)
+{
+  const int BUF_SIZE = 256;
+  char buf[BUF_SIZE];
+
+  // targetSpeed値が0の場合はwarningを出して終了する
+  if(targetSpeed == 0.0) {
+    snprintf(buf, BUF_SIZE, "The targetSpeed value passed to DistanceLineTracing is 0");
+    logger.logWarning(buf);
+    return false;
+  }
+
+  // targetDistance値が0以下の場合はwarningを出して終了する
+  if(targetDistance <= 0.0) {
+    snprintf(buf, BUF_SIZE, "The targetDistance value passed to DistanceLineTracing is %.2f",
+             targetDistance);
+    logger.logWarning(buf);
+    return false;
+  }
+
+  return true;
+}
+
+bool DistanceLineTracing::isMetPostcondition()
+{
+  // 初期値を代入
+  currentDistance = Mileage::calculateMileage(Measurer::getRightCount(), Measurer::getLeftCount());
+
+  // 走行距離が目標距離に到達
+  if(abs(currentDistance - initialDistance) >= targetDistance) return false;
+
+  return true;
+}
+
+void DistanceLineTracing::logRunning()
+{
+  const int BUF_SIZE = 256;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+  const char* str = isLeftEdge ? "true" : "false";
+
+  snprintf(buf, BUF_SIZE,
+           "Run DistanceLineTracing (targetDistance: %.2f, targetSpeed: %.2f, targetBrightness: "
+           "%d, basePwm: %d, gain: "
+           "(%.2f,%.2f,%.2f), isLeftEdge: %s)",
+           targetDistance, targetSpeed, targetBrightness, basePwm, gain.kp, gain.ki, gain.kd, str);
+  logger.log(buf);
+}

--- a/module/Motion/DistanceLineTracing.h
+++ b/module/Motion/DistanceLineTracing.h
@@ -1,0 +1,54 @@
+/**
+ * @file   DistanceLineTracing.h
+ * @brief  指定距離ライントレース動作
+ * @author YKhm20020
+ */
+
+#ifndef DISTANCE_LINE_TRACING_H
+#define DISTANCE_LINE_TRACING_H
+
+#include "LineTracing.h"
+#include "Timer.h"
+
+class DistanceLineTracing : public LineTracing {
+ public:
+  /**
+   * コンストラクタ
+   * @param _targetDistance 目標距離 0~
+   * @param _targetSpeed 目標速度 0~
+   * @param _targetBrightness 目標輝度 0~
+   * @param _gain PIDゲイン
+   * @param _isLeftEdge エッジの左右判定(true:左エッジ, false:右エッジ)
+   */
+  DistanceLineTracing(double _targetDistance, double _targetSpeed, int _targetBrightness,
+                      const PidGain& _gain, bool& _isLeftEdge);
+
+  /**
+   * @brief 指定距離だけライントレースする
+   */
+  using LineTracing::run;
+
+  /**
+   * @brief 指定距離ライントレースする際の事前条件判定をする
+   * @param targetSpeed 目標速度
+   * @note オーバーライド必須
+   */
+  bool isMetPrecondition(double targetSpeed) override;
+
+  /**
+   * @brief 指定距離ライントレースする際の継続条件判定をする　返り値がfalseでモーターが止まる
+   * @note オーバーライド必須
+   */
+  bool isMetPostcondition() override;
+
+  /**
+   * @brief 実行のログを取る
+   * @note オーバーライド必須
+   */
+  void logRunning() override;
+
+ private:
+  double targetDistance;  // 目標距離 0~
+};
+
+#endif

--- a/module/Motion/LineTracing.h
+++ b/module/Motion/LineTracing.h
@@ -9,6 +9,7 @@
 
 #include "Motion.h"
 #include "Mileage.h"
+#include "Timer.h"
 #include "Pid.h"
 #include "SpeedCalculator.h"
 
@@ -21,7 +22,7 @@ class LineTracing : public Motion {
    * @param _gain PIDゲイン
    * @param _isLeftEdge エッジの左右判定(true:左エッジ, false:右エッジ)
    */
-  LineTracing(double _targetSpeed, int _targetBrightness, const PidGain& _gain, bool _isLeftEdge);
+  LineTracing(double _targetSpeed, int _targetBrightness, const PidGain& _gain, bool& _isLeftEdge);
 
   /**
    * @brief ライントレースする
@@ -34,7 +35,7 @@ class LineTracing : public Motion {
    * @param targetSpeed 目標速度
    * @note オーバーライド必須
    */
-  bool isMetPrecondition(int basePwm, double targetSpeed);
+  virtual bool isMetPrecondition(double targetSpeed) = 0;
 
   /**
    * @brief ライントレースする際の継続条件判定をする　返り値がfalseでモーターが止まる
@@ -47,7 +48,7 @@ class LineTracing : public Motion {
    */
   virtual void logRunning();
 
- private:
+ protected:
   double targetSpeed;       // 目標速度 0~
   int targetBrightness;     // 目標輝度 0~
   int basePwm;              // 初期PWM値 -100~100
@@ -55,7 +56,9 @@ class LineTracing : public Motion {
   bool isLeftEdge;          // エッジの左右判定(true:左エッジ, false:右エッジ)
   double initLeftMileage;   // クラス呼び出し時の左車輪の走行距離
   double initRightMileage;  // クラス呼び出し時の右車輪の走行距離
-  class Timer timer;
+  double initialDistance;   // 実行前の走行距離
+  double currentDistance;   // 現在の走行距離
+  Timer timer;
 };
 
 #endif

--- a/test/ColorLineTracingTest.cpp
+++ b/test/ColorLineTracingTest.cpp
@@ -1,0 +1,245 @@
+/**
+ * @file   ColorLineTracingTest.cpp
+ * @brief  ColorLineTracingクラスのテスト
+ * @author YKhm20020
+ */
+
+#include "LineTracing.h"
+#include "ColorLineTracing.h"
+#include "Mileage.h"
+#include <gtest/gtest.h>
+#include <gtest/internal/gtest-port.h>
+
+using namespace std;
+
+namespace etrobocon2023_test {
+  // 最初3回の色取得で連続して指定色を取得するテストケース
+  TEST(ColorLineTracingTest, runToGetFirst)
+  {
+    COLOR targetColor = COLOR::GREEN;
+    double targetSpeed = 50.0;
+    double targetBrightness = 50.0;
+    int basePwm = 100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = true;
+    ColorLineTracing cl(targetColor, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    int expected = Mileage::calculateMileage(initialRightCount, initialLeftCount);
+
+    srand(9037);  // 3回連続して緑を取得する乱数シード
+    cl.run();     // 緑までライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    int actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_LT(expected, actual);  // 初期値より少しでも進んでいる
+  }
+
+  // 少し走ってから指定色を取得するテストケース
+  TEST(ColorLineTracingTest, runLeftEdge)
+  {
+    COLOR targetColor = COLOR::BLUE;
+    double targetSpeed = 100.0;
+    double targetBrightness = 45.0;
+    int basePwm = 100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = true;
+    ColorLineTracing cl(targetColor, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    int expected = Mileage::calculateMileage(initialRightCount, initialLeftCount);
+
+    srand(0);  // 最初に識別する色が青ではない乱数シード
+    cl.run();  // 青までライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    int actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_LT(expected, actual);  // 実行後に少しでも進んでいる
+  }
+
+  // 少し走ってから指定色を取得するテストケース
+  TEST(ColorLineTracingTest, runRightEdge)
+  {
+    COLOR targetColor = COLOR::RED;
+    double targetSpeed = 100.0;
+    double targetBrightness = 45.0;
+    int basePwm = 100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = false;
+    ColorLineTracing cl(targetColor, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    int expected = Mileage::calculateMileage(initialRightCount, initialLeftCount);
+
+    srand(0);  // 最初に識別する色が赤ではない乱数シード
+    cl.run();  // 赤までライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    int actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_LT(expected, actual);  // 実行後に少しでも進んでいる
+  }
+
+  // 少し走ってから指定色を取得するテストケース
+  TEST(ColorLineTracingTest, runBackLeftEdge)
+  {
+    COLOR targetColor = COLOR::YELLOW;
+    double targetSpeed = -100.0;
+    double targetBrightness = 45.0;
+    int basePwm = -100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = true;
+    ColorLineTracing cl(targetColor, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    int expected = Mileage::calculateMileage(initialRightCount, initialLeftCount);
+
+    srand(0);  // 最初に識別する色が黄ではない乱数シード
+    cl.run();  // 黄までライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    int actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_GT(expected, actual);  // 実行後に少しでも進んでいる
+  }
+
+  // 少し走ってから指定色を取得するテストケース
+  TEST(ColorLineTracingTest, runBackRightEdge)
+  {
+    COLOR targetColor = COLOR::GREEN;
+    double targetSpeed = -100.0;
+    double targetBrightness = 45.0;
+    int basePwm = -100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = false;
+    ColorLineTracing cl(targetColor, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    int expected = Mileage::calculateMileage(initialRightCount, initialLeftCount);
+
+    srand(0);  // 最初に識別する色が緑ではない乱数シード
+    cl.run();  // 緑までライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    int actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_GT(expected, actual);  // 実行後に少しでも進んでいる
+  }
+
+  TEST(ColorLineTracingTest, runZeroSpeed)
+  {
+    COLOR targetColor = COLOR::BLUE;
+    double targetSpeed = 0.0;
+    double targetBrightness = 45.0;
+    int basePwm = 100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = true;
+    ColorLineTracing cl(targetColor, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    int expected = Mileage::calculateMileage(initialRightCount, initialLeftCount);
+
+    // Warning文
+    string expectedOutput = "\x1b[36m";  // 文字色をシアンに
+    expectedOutput += "Warning: The targetSpeed value passed to ColorLineTracing is 0";
+    expectedOutput += "\n\x1b[39m";  // 文字色をデフォルトに戻す
+
+    srand(0);  // 最初に識別する色が青ではない乱数シード
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    cl.run();                            // 青までライントレースを実行
+    string actualOutput = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    int actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);  // ライントレース前後で走行距離に変化はない
+  }
+
+  TEST(ColorLineTracingTest, runNoneColor)
+  {
+    COLOR targetColor = COLOR::NONE;
+    double targetSpeed = 100.0;
+    double targetBrightness = 45.0;
+    int basePwm = 100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = true;
+    ColorLineTracing cl(targetColor, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    int expected = Mileage::calculateMileage(initialRightCount, initialLeftCount);
+
+    // Warning文
+    string expectedOutput = "\x1b[36m";  // 文字色をシアンに
+    expectedOutput += "Warning: The targetColor passed to ColorLineTracing is NONE";
+    expectedOutput += "\n\x1b[39m";  // 文字色をデフォルトに戻す
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    cl.run();                            // ライントレースを実行
+    string actualOutput = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    int actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);  // ライントレース前後で走行距離に変化はない
+  }
+}  // namespace etrobocon2023_test

--- a/test/DistanceLineTracingTest.cpp
+++ b/test/DistanceLineTracingTest.cpp
@@ -1,0 +1,226 @@
+/**
+ * @file   DistanceLineTracingTest.cpp
+ * @brief  DistanceLineTracingクラスのテスト
+ * @author YKhm20020
+ */
+
+#include "DistanceLineTracing.h"
+#include "Measurer.h"
+#include <gtest/gtest.h>
+#include <gtest/internal/gtest-port.h>
+
+using namespace std;
+
+namespace etrobocon2023_test {
+  TEST(DistanceLineTracingTest, runLeftEdge)
+  {
+    double targetSpeed = 100.0;
+    double targetDistance = 1000.0;
+    double targetBrightness = 45.0;
+    int basePwm = 100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = true;
+    DistanceLineTracing dl(targetDistance, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    double expected
+        = Mileage::calculateMileage(initialRightCount, initialLeftCount) + targetDistance;
+
+    // 一回のsetPWM()でダミーのモータカウントに加算される値はpwm * 0.05
+    double error = Mileage::calculateMileage(basePwm * 0.05, basePwm * 0.05);  // 許容誤差
+
+    dl.run();  // ライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_LE(expected, actual);  // ライントレース後に走行した距離が期待する走行距離以上である
+    EXPECT_GT(expected + error, actual);  // ライントレース後に走行した距離が許容誤差未満である
+  }
+
+  TEST(DistanceLineTracingTest, runRightEdge)
+  {
+    double targetSpeed = 100.0;
+    double targetDistance = 1000.0;
+    double targetBrightness = 45.0;
+    int basePwm = 100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = false;
+    DistanceLineTracing dl(targetDistance, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    double expected
+        = Mileage::calculateMileage(initialRightCount, initialLeftCount) + targetDistance;
+
+    // 一回のsetPWM()でダミーのモータカウントに加算される値はpwm * 0.05
+    double error = Mileage::calculateMileage(basePwm * 0.05, basePwm * 0.05);  // 許容誤差
+
+    dl.run();  // ライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_LE(expected, actual);  // ライントレース後に走行した距離が期待する走行距離以上である
+    EXPECT_GT(expected + error, actual);  // ライントレース後に走行した距離が許容誤差未満である
+  }
+
+  TEST(DistanceLineTracingTest, runBackLeftEdge)
+  {
+    double targetSpeed = -100.0;
+    double targetDistance = 100.0;
+    double targetBrightness = 45.0;
+    int basePwm = -100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = true;
+    DistanceLineTracing dl(targetDistance, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    double expected
+        = Mileage::calculateMileage(initialRightCount, initialLeftCount) - targetDistance;
+
+    // 一回のsetPWM()でダミーのモータカウントに加算される値はpwm * 0.05
+    double error = Mileage::calculateMileage(std::abs(basePwm * 0.05),
+                                             std::abs(basePwm * 0.05));  // 許容誤差
+
+    dl.run();  // ライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_GE(expected, actual);  // ライントレース後に走行した距離が期待する走行距離以下である
+    EXPECT_LT(expected - error, actual);  // ライントレース後に走行した距離が許容誤差未満である
+  }
+
+  TEST(DistanceLineTracingTest, runBackRightEdge)
+  {
+    double targetSpeed = -100.0;
+    double targetDistance = 1000.0;
+    double targetBrightness = 45.0;
+    int basePwm = -100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = false;
+    DistanceLineTracing dl(targetDistance, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    double expected
+        = Mileage::calculateMileage(initialRightCount, initialLeftCount) - targetDistance;
+
+    // 一回のsetPWM()でダミーのモータカウントに加算される値はpwm * 0.05
+    double error = Mileage::calculateMileage(std::abs(basePwm * 0.05),
+                                             std::abs(basePwm * 0.05));  // 許容誤差
+
+    dl.run();  // ライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_GE(expected, actual);  // ライントレース後に走行した距離が期待する走行距離以下である
+    EXPECT_LT(expected - error, actual);  // ライントレース後に走行した距離が許容誤差未満である
+  }
+
+  TEST(DistanceLineTracingTest, runZeroSpeed)
+  {
+    double targetSpeed = 0.0;
+    double targetDistance = 1000.0;
+    double targetBrightness = 45.0;
+    int basePwm = 100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = true;
+    DistanceLineTracing dl(targetDistance, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    double expected = Mileage::calculateMileage(initialRightCount, initialLeftCount);
+
+    // Warning文
+    string expectedOutput = "\x1b[36m";  // 文字色をシアンに
+    expectedOutput += "Warning: The targetSpeed value passed to DistanceLineTracing is 0";
+    expectedOutput += "\n\x1b[39m";  // 文字色をデフォルトに戻す
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    dl.run();                            // ライントレースを実行
+    string actualOutput = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);  // ライントレース前後で走行距離に変化はない
+  }
+
+  TEST(DistanceLineTracingTest, runMinusDistance)
+  {
+    double targetSpeed = 100.0;
+    double targetDistance = -1000.0;
+    double targetBrightness = 45.0;
+    int basePwm = 100;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+    bool isLeftEdge = true;
+    DistanceLineTracing dl(targetDistance, targetSpeed, targetBrightness, gain, isLeftEdge);
+
+    // モータカウントをリセット
+    Measurer::leftMotor->reset();
+    Measurer::rightMotor->reset();
+
+    // 初期値から期待する走行距離を求める
+    int initialRightCount = Measurer::getRightCount();
+    int initialLeftCount = Measurer::getLeftCount();
+    double expected = Mileage::calculateMileage(initialRightCount, initialLeftCount);
+
+    // Warning文
+    string expectedOutput = "\x1b[36m";  // 文字色をシアンに
+    expectedOutput += "Warning: The targetDistance value passed to DistanceLineTracing is -1000.00";
+    expectedOutput += "\n\x1b[39m";  // 文字色をデフォルトに戻す
+
+    testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
+    dl.run();                            // ライントレースを実行
+    string actualOutput = testing::internal::GetCapturedStdout();  // キャプチャ終了
+
+    // ライントレース後の走行距離
+    int rightCount = Measurer::getRightCount();
+    int leftCount = Measurer::getLeftCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
+    EXPECT_EQ(expected, actual);  // ライントレース前後で走行距離に変化はない
+  }
+}  // namespace etrobocon2023_test


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
テストに通っていません。原因はそれぞれ、
- ‘bool ColorLineTracing::isMetPrecondition(int, COLOR)’ marked ‘override’, but does not override は、オーバーライドできていない、

   →原因わかりました。LineTracing.h では、引数が (int basePwm, double targetSpeed)に。ColorLineTracing.h では、引数が (int basePwm, COLOR targetColor) になっていて、型違いによってオーバーライドできていないみたいです。

- cannot declare variable ‘cl’ to be of abstract type ‘ColorLineTracing’ は、抽象クラスのオブジェクトを生成しようとしているから、
- expression list treated as compound expression in initializer （参考文献を試した際のエラー）は、コンストラクタがないから、らしいです。

以下エラー文です。
```
In file included from /home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp:7:
/home/ykhm20020/etrobo/workspace/etrobocon2023/module/Motion/ColorLineTracing.h:38:8: error: ‘bool ColorLineTracing::isMetPrecondition(int, COLOR)’ marked ‘override’, but does not override
   38 |   bool isMetPrecondition(int basePwm, COLOR targetColor) override;
      |        ^~~~~~~~~~~~~~~~~
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp: In member function ‘virtual void etrobocon2023_test::ColorLineTracingTest_runToGetFirst_Test::TestBody()’:
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp:23:22: error: cannot declare variable ‘cl’ to be of abstract type ‘ColorLineTracing’
   23 |     ColorLineTracing cl(targetColor, targetBrightness, gain, isLeftEdge);
      |                      ^~
In file included from /home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp:7:
/home/ykhm20020/etrobo/workspace/etrobocon2023/module/Motion/ColorLineTracing.h:14:7: note:   because the following virtual functions are pure within ‘ColorLineTracing’:
   14 | class ColorLineTracing : public LineTracing
      |       ^~~~~~~~~~~~~~~~
In file included from /home/ykhm20020/etrobo/workspace/etrobocon2023/module/Motion/ColorLineTracing.h:10,
                 from /home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp:7:
/home/ykhm20020/etrobo/workspace/etrobocon2023/module/Motion/LineTracing.h:43:16: note:     ‘virtual bool LineTracing::isMetPostcondition()’
   43 |   virtual bool isMetPostcondition() = 0;
      |                ^~~~~~~~~~~~~~~~~~
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp: In member function ‘virtual void etrobocon2023_test::ColorLineTracingTest_runLeftEdge_Test::TestBody()’:
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp:53:22: error: cannot declare variable ‘cl’ to be of abstract type ‘ColorLineTracing’
   53 |     ColorLineTracing cl(targetColor, targetBrightness, gain, isLeftEdge);
      |                      ^~
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp: In member function ‘virtual void etrobocon2023_test::ColorLineTracingTest_runRightEdge_Test::TestBody()’:
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp:79:22: error: cannot declare variable ‘cl’ to be of abstract type ‘ColorLineTracing’
   79 |     ColorLineTracing cl(targetColor, targetBrightness, gain, isLeftEdge);
      |                      ^~
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp: In member function ‘virtual void etrobocon2023_test::ColorLineTracingTest_runBackLeftEdge_Test::TestBody()’:
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp:105:22: error: cannot declare variable ‘cl’ to be of abstract type ‘ColorLineTracing’
  105 |     ColorLineTracing cl(targetColor, targetBrightness, gain, isLeftEdge);
      |                      ^~
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp: In member function ‘virtual void etrobocon2023_test::ColorLineTracingTest_runBackRightEdge_Test::TestBody()’:
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp:131:22: error: cannot declare variable ‘cl’ to be of abstract type ‘ColorLineTracing’
  131 |     ColorLineTracing cl(targetColor, targetBrightness, gain, isLeftEdge);
      |                      ^~
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp: In member function ‘virtual void etrobocon2023_test::ColorLineTracingTest_runZeroPWM_Test::TestBody()’:
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp:156:22: error: cannot declare variable ‘cl’ to be of abstract type ‘ColorLineTracing’
  156 |     ColorLineTracing cl(targetColor, targetBrightness, gain, isLeftEdge);
      |                      ^~
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp: In member function ‘virtual void etrobocon2023_test::ColorLineTracingTest_runNoneColor_Test::TestBody()’:
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp:189:22: error: cannot declare variable ‘cl’ to be of abstract type ‘ColorLineTracing’
  189 |     ColorLineTracing cl(targetColor, targetBrightness, gain, isLeftEdge);
      |                      ^~
make[3]: *** [CMakeFiles/etrobocon2023_test.dir/build.make:102: CMakeFiles/etrobocon2023_test.dir/test/ColorLineTracingTest.cpp.o] Error 1
make[3]: Leaving directory '/home/ykhm20020/etrobo/hrp3/sdk/workspace/etrobocon2023/build'
make[2]: *** [CMakeFiles/Makefile2:140: CMakeFiles/etrobocon2023_test.dir/all] Error 2
make[2]: Leaving directory '/home/ykhm20020/etrobo/hrp3/sdk/workspace/etrobocon2023/build'
make[1]: *** [Makefile:141: all] Error 2
make[1]: Leaving directory '/home/ykhm20020/etrobo/hrp3/sdk/workspace/etrobocon2023/build'
make: *** [Makefile:47: gtest] Error 2

```

![スクリーンショット 2023-07-02 201527](https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010507/58d7c9db-7e19-42dd-b203-5c2c5292ff48)

# 動作テスト

## 添付資料
以下サイトの方法試しましたが、通りませんでした。
[「純粋仮想関数」について勉強しました](https://www.pgls-kl.com/article/article_118.html)

試した結果のエラー文は以下の通りでした。ポインタ外してみたのですが、その場合は上のエラー文と同じものが表示されました。

```
/home/ykhm20020/etrobo/workspace/etrobocon2023/test/ColorLineTracingTest.cpp:23:73: error: expression list treated as compound expression in initializer [-fpermissive]
   23 |    ColorLineTracing *cl(targetColor, targetBrightness, gain, isLeftEdge) = new ColorLineTracing();
      |                                                                        ^
```
