### PR TITLE
close #69 キャリブレーションを左右ボタンのみで実行

### DIFF
--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -1,7 +1,7 @@
 /**
  * @file Calibrator.cpp
  * @brief キャリブレーションからスタートまでを担当するクラス
- * @author aridome222
+ * @author aridome222 KakinokiKanta
  */
 
 #include "Calibrator.h"
@@ -26,21 +26,21 @@ void Calibrator::selectCourse()
 
   logger.log("Select a Course");
   logger.log(">> Set Left Course");
-  // 中央ボタンが押されたら確定する
-  while(!measurer.getEnterButton()) {
-    // 左ボタンが押されたらLコースをセットする
-    if(measurer.getLeftButton() && !_isLeftCourse) {
+  // 右ボタンが押されたら確定する
+  while(!Measurer::getRightButton()) {
+    if(Measurer::getLeftButton() && !_isLeftCourse) {
+      // 左ボタンが押されたときRコースがセットされていれば、Lコースをセットする
       _isLeftCourse = true;
       logger.log(">> Set Left Course");
-    }
-
-    // 右ボタンが押されたらRコースをセットする
-    if(measurer.getRightButton() && _isLeftCourse) {
+      timer.sleep(500);  // 500ミリ秒スリープ
+    } else if(Measurer::getLeftButton() && _isLeftCourse) {
+      // 左ボタンが押されたときLコースがセットされていれば、Rコースをセットする
       _isLeftCourse = false;
       logger.log(">> Set Right Course");
+      timer.sleep(500);  // 500ミリ秒スリープ
+    } else {
+      timer.sleep(10);  // 10ミリ秒スリープ
     }
-
-    timer.sleep();  // 10ミリ秒スリープ
   }
 
   isLeftCourse = _isLeftCourse;
@@ -57,13 +57,13 @@ void Calibrator::measureTargetBrightness()
   char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
   Logger logger;
 
-  // ライン上で中央ボタンを押して、黒と白の中間色の輝度を取得する
-  logger.log("Press the Center Button on the Line");
-  // 中央ボタンが押されるまで待機
-  while(!measurer.getEnterButton()) {
+  // ライン上で右ボタンを押して、黒と白の中間色の輝度を取得する
+  logger.log("Press the Right Button on the Line");
+  // 右ボタンが押されるまで待機
+  while(!Measurer::getRightButton()) {
     timer.sleep();  // 10ミリ秒スリープ
   }
-  targetBrightness = measurer.getBrightness();
+  targetBrightness = Measurer::getBrightness();
   snprintf(buf, BUF_SIZE, ">> Target Brightness Value is %d", targetBrightness);
   logger.log(buf);
 }
@@ -80,7 +80,7 @@ void Calibrator::waitForStart()
   logger.log(buf);
 
   // startDistance以内の距離に物体がない間待機する
-  while(measurer.getForwardDistance() > startDistance) {
+  while(Measurer::getForwardDistance() > startDistance) {
     timer.sleep();  // 10ミリ秒スリープ
   }
 }

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -39,7 +39,7 @@ void Calibrator::selectCourse()
       logger.log(">> Set Right Course");
       timer.sleep(500);  // 500ミリ秒スリープ
     } else {
-      timer.sleep(10);  // 10ミリ秒スリープ
+      timer.sleep();  // 10ミリ秒スリープ
     }
   }
 
@@ -59,13 +59,21 @@ void Calibrator::measureTargetBrightness()
 
   // ライン上で右ボタンを押して、黒と白の中間色の輝度を取得する
   logger.log("Press the Right Button on the Line");
-  // 右ボタンが押されるまで待機
-  while(!Measurer::getRightButton()) {
+  targetBrightness = -1;
+
+  // 左ボタンで輝度を取得し、右ボタンで待機状態に入る
+  while(targetBrightness < 0 || !Measurer::getRightButton()) {
+    // 左ボタンが押されるまで待機
+    while (!Measurer::getLeftButton()) {
+      timer.sleep();  // 10ミリ秒スリープ
+    }
+    
+    // 輝度取得
+    targetBrightness = Measurer::getBrightness();
+    snprintf(buf, BUF_SIZE, ">> Target Brightness Value is %d", targetBrightness);
+    logger.log(buf);
     timer.sleep();  // 10ミリ秒スリープ
   }
-  targetBrightness = Measurer::getBrightness();
-  snprintf(buf, BUF_SIZE, ">> Target Brightness Value is %d", targetBrightness);
-  logger.log(buf);
 }
 
 void Calibrator::waitForStart()

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -64,7 +64,7 @@ void Calibrator::measureTargetBrightness()
   // 左ボタンで輝度を取得し、右ボタンで待機状態に入る
   while(targetBrightness < 0 || !Measurer::getRightButton()) {
     // 左ボタンが押されるまで待機
-    while (!Measurer::getLeftButton()) {
+    while(!Measurer::getLeftButton()) {
       timer.sleep();  // 10ミリ秒スリープ
     }
     

--- a/module/Calibrator.cpp
+++ b/module/Calibrator.cpp
@@ -67,7 +67,7 @@ void Calibrator::measureTargetBrightness()
     while(!Measurer::getLeftButton()) {
       timer.sleep();  // 10ミリ秒スリープ
     }
-    
+
     // 輝度取得
     targetBrightness = Measurer::getBrightness();
     snprintf(buf, BUF_SIZE, ">> Target Brightness Value is %d", targetBrightness);

--- a/module/Calibrator.h
+++ b/module/Calibrator.h
@@ -1,7 +1,7 @@
 /**
  * @file Calibrator.h
  * @brief キャリブレーションからスタートまでを担当するクラス
- * @author aridome222
+ * @author aridome222 KakinokiKanta
  */
 
 #ifndef CALIBRATOR_H
@@ -43,7 +43,6 @@ class Calibrator {
  private:
   bool isLeftCourse;     // true:Lコース, false: Rコース
   int targetBrightness;  // 目標輝度
-  static Measurer measurer;
   Timer timer;
 
   /**

--- a/test/dummy/ev3api_button.h
+++ b/test/dummy/ev3api_button.h
@@ -18,7 +18,7 @@ typedef enum {
   RIGHT_BUTTON = 1,  // 右ボタン
   UP_BUTTON = 2,     // Spikeでは使えないけど一応
   DOWN_BUTTON = 3,   // Spikeでは使えないけど一応
-  ENTER_BUTTON = 4,  // 中央ボタン
+  ENTER_BUTTON = 4,  // 中央ボタン(今年の環境では使用できない)
   BACK_BUTTON = 5,   // Spikeでは使えないけど一応
   TNUM_BUTTON = 6    // Spikeでは使えないけど一応
 } button_t;


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- キャリブレーション時、(走行体正面から見て)左ボタンでコースの左右を切り替えて、右ボタンで決定するように変更
- 輝度取得時も右ボタンで決定するように変更

# 動作テスト
- 実機でキャリブレーションが行えることを確認
