### PR TITLE
close #134 回頭補正のキャリブレーション修正

### DIFF
--- a/module/Motion/CorrectingRotation.h
+++ b/module/Motion/CorrectingRotation.h
@@ -7,18 +7,22 @@
 #ifndef CORRECTING_ROTATION_H
 #define CORRECTING_ROTATION_H
 
+#include "SystemInfo.h"
 #include "CompositeMotion.h"
 #include "StringOperator.h"
-#include "AngleRotation.h"
+#include "Mileage.h"
+#include "Timer.h"
+#include "SpeedCalculator.h"
+#include "PwmRotation.h"
 
 class CorrectingRotation : public CompositeMotion {
  public:
   /**
    * コンストラクタ
    * @param _targetAngle 目標角度(deg) 0~89
-   * @param _targetSpeed 目標速度[mm/s]
+   * @param _pwm PWM値 0~100
    */
-  CorrectingRotation(int _targetAngle, double _targetSpeed);
+  CorrectingRotation(int _targetAngle, int _pwm);
 
   /**
    * @brief 角度補正回頭する
@@ -38,7 +42,7 @@ class CorrectingRotation : public CompositeMotion {
  private:
   static constexpr int NO_CORRECTION_ANGLE = 2;  // 補正免除角度(deg)
   int targetAngle;                               // 目標角度(deg) 0~89
-  double targetSpeed;                            // 目標速度[mm/s]
+  int pwm;                                       // PWM値 0~100
   Timer timer;
 };
 

--- a/module/MotionParser.cpp
+++ b/module/MotionParser.cpp
@@ -115,8 +115,8 @@ vector<Motion*> MotionParser::createMotions(const char* commandFilePath, int tar
     }
     */
     else if(command == COMMAND::XR) {  // 角度補正回頭の追加
-      CorrectingRotation* xr = new CorrectingRotation(atoi(params[1]),   // 目標角度
-                                                      atof(params[2]));  // 目標速度
+      CorrectingRotation* xr = new CorrectingRotation(atoi(params[1]),  // 目標角度
+                                                      atof(params[2]));  // 角度補正回頭の目標PWM
 
       motionList.push_back(xr);                                    // 動作リストに追加
     } else if(command == COMMAND::IS) {                            // 交点内移動（直進）

--- a/test/CorrectingRotationTest.cpp
+++ b/test/CorrectingRotationTest.cpp
@@ -20,8 +20,8 @@ namespace etrobocon2023_test {
   TEST(CorrectingRotationTest, runClockwiseToZero)
   {
     int targetAngle = 0;
-    double targetSpeed = 60.0;
-    CorrectingRotation xRotation(targetAngle, targetSpeed);
+    int pwm = 60;
+    CorrectingRotation xRotation(targetAngle, pwm);
 
     // rearCamera.shで-2.1を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2023/scripts/rear_camera_request.sh");
@@ -53,8 +53,8 @@ namespace etrobocon2023_test {
   TEST(CorrectingRotationTest, runAnticlockwiseToZero)
   {
     int targetAngle = 0;
-    double targetSpeed = 60.0;
-    CorrectingRotation xRotation(targetAngle, targetSpeed);
+    int pwm = 60;
+    CorrectingRotation xRotation(targetAngle, pwm);
 
     // rearCamera.shで5.9を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2023/scripts/rear_camera_request.sh");
@@ -84,8 +84,8 @@ namespace etrobocon2023_test {
   TEST(CorrectingRotationTest, runClockwiseTo45)
   {
     int targetAngle = 45;
-    double targetSpeed = 60.0;
-    CorrectingRotation xRotation(targetAngle, targetSpeed);
+    int pwm = 60;
+    CorrectingRotation xRotation(targetAngle, pwm);
 
     // rearCamera.shで-49.9を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2023/scripts/rear_camera_request.sh");
@@ -115,8 +115,8 @@ namespace etrobocon2023_test {
   TEST(CorrectingRotationTest, runAnticlockwiseTo45)
   {
     int targetAngle = 45;
-    double targetSpeed = 60.0;
-    CorrectingRotation xRotation(targetAngle, targetSpeed);
+    int pwm = 60;
+    CorrectingRotation xRotation(targetAngle, pwm);
 
     // rearCamera.shで50.1を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2023/scripts/rear_camera_request.sh");
@@ -146,8 +146,8 @@ namespace etrobocon2023_test {
   TEST(CorrectingRotationTest, runClockwiseTo90)
   {
     int targetAngle = 0;
-    double targetSpeed = 60.0;
-    CorrectingRotation xRotation(targetAngle, targetSpeed);
+    int pwm = 60;
+    CorrectingRotation xRotation(targetAngle, pwm);
 
     // rearCamera.shで87.9を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2023/scripts/rear_camera_request.sh");
@@ -177,8 +177,8 @@ namespace etrobocon2023_test {
   TEST(CorrectingRotationTest, runAnticlockwiseTo90)
   {
     int targetAngle = 0;
-    double targetSpeed = 60.0;
-    CorrectingRotation xRotation(targetAngle, targetSpeed);
+    int pwm = 60;
+    CorrectingRotation xRotation(targetAngle, pwm);
 
     // rearCamera.shで-85.1を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2023/scripts/rear_camera_request.sh");
@@ -208,8 +208,8 @@ namespace etrobocon2023_test {
   TEST(CorrectingRotationTest, runNoCorrecting)
   {
     int targetAngle = 0;
-    double targetSpeed = 60.0;
-    CorrectingRotation xRotation(targetAngle, targetSpeed);
+    int pwm = 60;
+    CorrectingRotation xRotation(targetAngle, pwm);
 
     // rearCamera.shで-2.0を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2023/scripts/rear_camera_request.sh");
@@ -235,11 +235,11 @@ namespace etrobocon2023_test {
     EXPECT_EQ(expectedRight, actualRight);
   }
 
-  TEST(CorrectingRotationTest, runZerotargetSpeed)
+  TEST(CorrectingRotationTest, runZeropwm)
   {
     int targetAngle = 0;
-    double targetSpeed = 0.0;
-    CorrectingRotation xRotation(targetAngle, targetSpeed);
+    int pwm = 0;
+    CorrectingRotation xRotation(targetAngle, pwm);
 
     // rearCamera.shで-5.0を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2023/scripts/rear_camera_request.sh");
@@ -247,8 +247,7 @@ namespace etrobocon2023_test {
 
     // Warning文
     string expectedOutput = "\x1b[36m";  // 文字色をシアンに
-    expectedOutput += "Warning: The targetSpeed value passed to CorrectingRotation is "
-                      + to_string(targetSpeed);
+    expectedOutput += "Warning: The pwm value passed to CorrectingRotation is " + to_string(pwm);
     expectedOutput += "\n\x1b[39m";  // 文字色をデフォルトに戻す
 
     // 期待する車輪ごとの回頭角度
@@ -274,11 +273,11 @@ namespace etrobocon2023_test {
     EXPECT_EQ(expectedOutput, actualOutput);  // 標準出力でWarningを出している
   }
 
-  TEST(CorrectingRotationTest, runMinustargetSpeed)
+  TEST(CorrectingRotationTest, runMinuspwm)
   {
     int targetAngle = 0;
-    double targetSpeed = -100.0;
-    CorrectingRotation xRotation(targetAngle, targetSpeed);
+    int pwm = -100;
+    CorrectingRotation xRotation(targetAngle, pwm);
 
     // rearCamera.shで-5.0を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2023/scripts/rear_camera_request.sh");
@@ -286,8 +285,7 @@ namespace etrobocon2023_test {
 
     // Warning文
     string expectedOutput = "\x1b[36m";  // 文字色をシアンに
-    expectedOutput += "Warning: The targetSpeed value passed to CorrectingRotation is "
-                      + to_string(targetSpeed);
+    expectedOutput += "Warning: The pwm value passed to CorrectingRotation is " + to_string(pwm);
     expectedOutput += "\n\x1b[39m";  // 文字色をデフォルトに戻す
 
     // 期待する車輪ごとの回頭角度
@@ -316,8 +314,8 @@ namespace etrobocon2023_test {
   TEST(CorrectingRotationTest, runMinusAngle)
   {
     int targetAngle = -1;
-    double targetSpeed = 60.0;
-    CorrectingRotation xRotation(targetAngle, targetSpeed);
+    int pwm = 60;
+    CorrectingRotation xRotation(targetAngle, pwm);
 
     // rearCamera.shで-5.0を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2023/scripts/rear_camera_request.sh");
@@ -355,8 +353,8 @@ namespace etrobocon2023_test {
   TEST(CorrectingRotationTest, runOverAngle)
   {
     int targetAngle = 90;
-    double targetSpeed = 60.0;
-    CorrectingRotation xRotation(targetAngle, targetSpeed);
+    int pwm = 60;
+    CorrectingRotation xRotation(targetAngle, pwm);
 
     // rearCamera.shで-5.0を返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2023/scripts/rear_camera_request.sh");
@@ -395,8 +393,8 @@ namespace etrobocon2023_test {
   TEST(CorrectingRotationTest, runReturnNone)
   {
     int targetAngle = 45;
-    double targetSpeed = 60.0;
-    CorrectingRotation xRotation(targetAngle, targetSpeed);
+    int pwm = 60;
+    CorrectingRotation xRotation(targetAngle, pwm);
 
     // rearCamera.shでNoneを返すように書き換える
     system("echo \"#!/bin/bash\" > ./etrobocon2023/scripts/rear_camera_request.sh");


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 10/19追記

- 今回、回頭補正のプログラムをtargetSpeedからpwmに変えましたが、targetSpeedを使ったARコマンドの方が、ブロックを運んでいない状態から運んでいる状態になった時に対応できるらしいので、**このプルリクはマージしないで、クローズする予定**です。

- キャリブレーションに関しては、特にエラーはなく、下記のように”[Info] Successfully calibrated”と表示されれば成功です。（サービス起動状態でのキャリブレーション）

```
et2023@katlab2:~/work/RasPike/sdk/workspace/etrobocon2023 $ sudo systemctl status rear-camera.service
● rear-camera.service - Rear camera system
     Loaded: loaded (/etc/systemd/system/rear-camera.service; enabled; vendor preset: enabled)
     Active: active (running) since Thu 2023-10-19 04:47:17 BST; 2s ago
   Main PID: 5882 (bash)
      Tasks: 9 (limit: 4915)
        CPU: 1.724s
     CGroup: /system.slice/rear-camera.service
             ├─5882 /bin/bash -c if [ -f /home/et2023/work/RasPike/sdk/workspace/etrobocon2023/scripts/start_rear_camera.sh ]; then /home/et2023/work/Ra>
             ├─5883 /bin/bash /home/et2023/work/RasPike/sdk/workspace/etrobocon2023/scripts/start_rear_camera.sh --server --server-port 10338
             └─5884 python -m src --server --server-port 10338

Oct 19 04:47:17 katlab2 systemd[1]: Started Rear camera system.
Oct 19 04:47:19 katlab2 bash[5884]: [1:15:12.214424821] [5884]  INFO Camera camera_manager.cpp:299 libcamera v0.0.4+22-923f5d70
Oct 19 04:47:19 katlab2 bash[5884]: [1:15:12.247386928] [5895]  WARN RPI raspberrypi.cpp:1357 Mismatch between Unicam and CamHelper for embedded data us>
Oct 19 04:47:19 katlab2 bash[5884]: [1:15:12.248592429] [5895]  INFO RPI raspberrypi.cpp:1476 Registered camera /base/soc/i2c0mux/i2c@1/imx219@10 to Uni>
Oct 19 04:47:19 katlab2 bash[5884]: [1:15:12.255742587] [5884]  INFO Camera camera.cpp:1028 configuring streams: (0) 1640x1232-RGB888 (1) 1640x1232-SBGG>
Oct 19 04:47:19 katlab2 bash[5884]: [1:15:12.256623148] [5895]  INFO RPI raspberrypi.cpp:851 Sensor: /base/soc/i2c0mux/i2c@1/imx219@10 - Selected sensor>
et2023@katlab2:~/work/RasPike/sdk/workspace/etrobocon2023 $ ./scripts/rear_camera_request.sh --calibrate
[Info] Successfully calibrated
```

- サービス停止状態のキャリブレーション成功時は下記の表示が出ます。（最後に"None"が出ますが、パラメータファイルは正常に作成されています。"None"が出るのは黒線検出をなぜかしているためだと思われる）
```
et2023@katlab2:~/work/RasPike/sdk/workspace/etrobocon2023 $ sudo systemctl stop rear-camera.service
et2023@katlab2:~/work/RasPike/sdk/workspace/etrobocon2023 $ sudo systemctl status rear-camera.service
● rear-camera.service - Rear camera system
     Loaded: loaded (/etc/systemd/system/rear-camera.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Thu 2023-10-19 04:54:47 BST; 4s ago
    Process: 5882 ExecStart=/bin/bash -c if [ -f ${SCRIPT_PATH} ]; then ${SCRIPT_PATH} --server --server-port ${PORT}; else echo 'Not found(${SCRIPT_PAT>
   Main PID: 5882 (code=killed, signal=TERM)
        CPU: 50.612s

Oct 19 04:47:19 katlab2 bash[5884]: [1:15:12.214424821] [5884]  INFO Camera camera_manager.cpp:299 libcamera v0.0.4+22-923f5d70
Oct 19 04:47:19 katlab2 bash[5884]: [1:15:12.247386928] [5895]  WARN RPI raspberrypi.cpp:1357 Mismatch between Unicam and CamHelper for embedded data us>
Oct 19 04:47:19 katlab2 bash[5884]: [1:15:12.248592429] [5895]  INFO RPI raspberrypi.cpp:1476 Registered camera /base/soc/i2c0mux/i2c@1/imx219@10 to Uni>
Oct 19 04:47:19 katlab2 bash[5884]: [1:15:12.255742587] [5884]  INFO Camera camera.cpp:1028 configuring streams: (0) 1640x1232-RGB888 (1) 1640x1232-SBGG>
Oct 19 04:47:19 katlab2 bash[5884]: [1:15:12.256623148] [5895]  INFO RPI raspberrypi.cpp:851 Sensor: /base/soc/i2c0mux/i2c@1/imx219@10 - Selected sensor>
Oct 19 04:54:47 katlab2 systemd[1]: Stopping Rear camera system...
Oct 19 04:54:47 katlab2 systemd[1]: rear-camera.service: Killing process 5895 (python) with signal SIGKILL.
Oct 19 04:54:47 katlab2 systemd[1]: rear-camera.service: Succeeded.
Oct 19 04:54:47 katlab2 systemd[1]: Stopped Rear camera system.
Oct 19 04:54:47 katlab2 systemd[1]: rear-camera.service: Consumed 50.612s CPU time.
et2023@katlab2:~/work/RasPike/sdk/workspace/etrobocon2023 $ ./scripts/start_rear_camera.sh --calibrate
[1:23:07.298193163] [6177]  INFO Camera camera_manager.cpp:299 libcamera v0.0.4+22-923f5d70
[1:23:07.329378616] [6181]  WARN RPI raspberrypi.cpp:1357 Mismatch between Unicam and CamHelper for embedded data usage!
[1:23:07.330396504] [6181]  INFO RPI raspberrypi.cpp:1476 Registered camera /base/soc/i2c0mux/i2c@1/imx219@10 to Unicam device /dev/media0 and ISP device /dev/media2
[1:23:07.338219487] [6177]  INFO Camera camera.cpp:1028 configuring streams: (0) 1640x1232-RGB888 (1) 1640x1232-SBGGR10_CSI2P
[1:23:07.338631990] [6181]  INFO RPI raspberrypi.cpp:851 Sensor: /base/soc/i2c0mux/i2c@1/imx219@10 - Selected sensor format: 1640x1232-SBGGR10_1X10 - Selected unicam format: 1640x1232-pBAA
None
```

# 今回のタスクについて
キャリブレーションでエラーが出るとのことで、実際に実機の環境で試したところ案外上手くいったため、
回頭補正のプログラムをtargetSpeed（目標速度）ではなく、pwm値を用いるように修正し、実機での動作確認まで行いました。

# 変更点
- 回頭補正のプログラム修正（targetSpeed ⇒ pwm値に変更）

# キャリブレーションでエラーが出たが何故か直った件について
10/19追記　エラー再現できました。
サービス起動状態でキャリブレしてパラメータファイルを作成し、次にサービスを停止させてキャリブレしたところ、同様のエラーがでました。原因は、サービス起動時に作成されたパラメータファイルはet2023ユーザではなくroot権限で作成されたことにより、サービス停止時にet2023ユーザがroot権限で既に作成されたパラメータファイルへの上書き権限を持っていないため、エラーが出たのだと思います。
まぁ正直、このエラーが出る操作手順を普通は踏まないと思うので、エラー修正は必要ないと思います。

ーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーー

エラーの話の前に、リアカメラシステムServiceと、キャリブレーションについて少し補足。

リアカメラシステムServiceはリアカメラを制御し、自動再起動を備えたLinuxベースのサービスです。一度Serviceの登録をしてしまえば、実機環境の再起動後も自動でServiceが起動してくれるため、再起動のたびにServiceを起動する必要は無いです。（既にServiceの登録はしているので、登録する必要は無いです。）

> リアカメラシステムServiceの詳細については、rear_camera_py/rear-camera.serviceを参照してください。

キャリブレーションには、リアカメラシステムServiceを起動しているとき用のキャリブレーションコマンドと、Serviceを起動させてない（停止させた）とき用のキャリブレーションコマンドがあり、今回その両方を試しました。また、キャリブレーションに成功すると、射影変換用パラメータファイルが生成されます。(rear_camera_param.npyとtmp_rear_camera_distance_param.json)

パラメータファイルがrear_camera_pyに無い状態で、Serviceを起動している時とそうでない時でキャリブレ試したところ、
Service停止時のキャリブレで下記のようなエラーが発生しました。エラー内容は、恐らく 'rear_camera_param.npy' というファイルに書き込み権限がないために発生しているようで、確か記憶が正しければ、自分でも分からないのですが、make debugコマンドの中身であるpython -m src --debugをsudo python -m src --debugにして実行したら直ったのですが、sudoを消してもう一度やってみたらエラーを吐かなかったので、それが原因なのかよく分かりません。明日もう一度調べてみようと思います。

```
et2023@katlab2:~/work/RasPike/sdk/workspace/etrobocon2023 $ ./scripts/start_rear_camera.sh --calibrate
[3:50:53.976515068] [27809]  INFO Camera camera_manager.cpp:299 libcamera v0.0.4+22-923f5d70
[3:50:54.008108633] [27810]  WARN RPI raspberrypi.cpp:1357 Mismatch between Unicam and CamHelper for embedded data usage!
[3:50:54.009128239] [27810]  INFO RPI raspberrypi.cpp:1476 Registered camera /base/soc/i2c0mux/i2c@1/imx219@10 to Unicam device /dev/media3 and ISP device /dev/media0
[3:50:54.016543128] [27809]  INFO Camera camera.cpp:1028 configuring streams: (0) 1640x1232-RGB888 (1) 1640x1232-SBGGR10_CSI2P
[3:50:54.016933434] [27810]  INFO RPI raspberrypi.cpp:851 Sensor: /base/soc/i2c0mux/i2c@1/imx219@10 - Selected sensor format: 1640x1232-SBGGR10_1X10 - Selected unicam format: 1640x1232-pBAA
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/et2023/work/RasPike/sdk/workspace/etrobocon2023/rear_camera_py/src/__main__.py", line 37, in <module>
    msg = calibrator.calibrate()
  File "/home/et2023/work/RasPike/sdk/workspace/etrobocon2023/rear_camera_py/src/calibrator.py", line 113, in calibrate
    np.save(self.__trans_mat_file, trans_mat)
  File "/home/et2023/.local/lib/python3.9/site-packages/numpy/lib/npyio.py", line 542, in save
    file_ctx = open(file, "wb")
PermissionError: [Errno 13] Permission denied: 'rear_camera_param.npy'
```

# 動作テスト
- 補足資料にある動画のように、走行体を黒線からずらして回頭補正コマンドを実行

表1：pwm値を使用した回頭補正
| 補正前のずれ | 算出した補正角度 |
| :---: | :---: |
| 10 | 12 |
| 20 | 21 |
| 30 | 32 |

表2：targetSpeedを使用した回頭補正(前回の動作テストから引用ticket-78)
| 補正前のずれ | 算出した補正角度 |
| :---: | :---: |
| 10 | 10 |
| 20 | 22 |
| 30 | 32 |

-  補足資料の2つ目の動画のように、走行体の配置によって、本来とは逆の方向に回頭してしまうことがある。
考えられる原因として、去年よりもリアカメラの画角が高いのが誤作動に繋がっていると思われる。走行体の中心線と黒線の為す角を算出するプログラムを詳しく見る必要がある。

# 補足資料
回頭補正動作例(ずれ20度、補正角度21度)

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/5aa7bc1b-f462-4493-b4ea-e5dcd96855e1

回頭補正動作失敗例(ずれ20度、補正角度-23度)

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/a302d345-8742-4bb3-a055-b8ad4ded6de2

台形補正前画像

![angle_2023-10-17_12-56-25 112821_captured](https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/afe93de7-8d31-4bd8-b1f3-13b25cd4b096)

台形補正後画像

![angle_2023-10-17_12-56-25 112821_transformed](https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/6fffc95b-fd41-40f2-94ac-af204d95dd41)

角度算出の例

![angle_2023-10-17_12-34-46 400869_detected](https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/78dd7105-9afc-4d5f-9960-480ebe14a17d)