### PR TITLE
close #133 急加速・無限回頭の調査と対応

### DIFF
--- a/module/API/Measurer.cpp
+++ b/module/API/Measurer.cpp
@@ -37,10 +37,29 @@ int Measurer::getLeftCount()
   return leftMotor->getCount();
 }
 
+// 左モータ角位置更新
+void Measurer::setLeftCount(int count)
+{
+  leftMotor->setCount(count);
+}
+
 // 右モータ角位置取得
 int Measurer::getRightCount()
 {
   return rightMotor->getCount();
+}
+
+// 右モータ角位置更新
+void Measurer::setRightCount(int count)
+{
+  rightMotor->setCount(count);
+}
+
+// モータ角位置の初期化
+void Measurer::resetCount()
+{
+  Measurer::setLeftCount(0);
+  Measurer::setRightCount(0);
 }
 
 // アームモータ角位置取得

--- a/module/API/Measurer.h
+++ b/module/API/Measurer.h
@@ -42,10 +42,27 @@ class Measurer {
   static int getLeftCount();
 
   /**
+   * 左モータ角位置を更新
+   * @param 左モータ角位置[deg]
+   */
+  static void setLeftCount(int count);
+
+  /**
    * 右モータ角位置を取得
    * @return 右モータ角位置[deg]
    */
   static int getRightCount();
+
+  /**
+   * 右モータ角位置を更新
+   * @param 右モータ角位置[deg]
+   */
+  static void setRightCount(int count);
+
+  /**
+   * モータ角位置を初期化
+   */
+  static void resetCount();
 
   /**
    * アームモータ角位置を取得

--- a/module/AreaMaster.cpp
+++ b/module/AreaMaster.cpp
@@ -39,6 +39,7 @@ void AreaMaster::run()
 
   // 各動作を実行する
   for(const auto& motion : motionList) {
+    Measurer::resetCount();
     motion->logRunning();
     motion->run();
   }

--- a/module/AreaMaster.h
+++ b/module/AreaMaster.h
@@ -12,6 +12,7 @@
 #include <string.h>
 #include "MotionParser.h"
 #include "Logger.h"
+#include "Measurer.h"
 
 // エリア名を持つ列挙型変数（LineTrace = 0, DoubleLoop = 1, BlockDeTreasure = 2）
 enum Area { LineTrace, DoubleLoop, BlockDeTreasure };

--- a/test/dummy/Motor.h
+++ b/test/dummy/Motor.h
@@ -31,6 +31,11 @@ namespace ev3api {
     int getCount();
 
     /**
+     * モータ角位置更新
+     */
+    void setCount(int count){};
+
+    /**
      * pwm値設定
      * @param pwm pwm値
      */


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 急加速・無限回頭についての調査結果

## 急加速について

結論：よくわからん。

検証中には急加速(両輪のPWMが100になり走り続ける)を確認できなかった。
Measurer::get○○Count()を0しか返さないよう書き換えたところ再現はできたため、距離センサーと同様にモータカウントを取得できなくなっている可能性はあるが確認できてはいない。

## 無限回頭について

結論：オーバーフローの問題だった可能性がある

走行開始時にモータカウントをint型の上限ギリギリ-10に設定し、回頭した結果、回頭し続ける挙動を確認できた。(動画参照)

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/83441177/b02e6a15-388b-4444-9e83-7ae55cac73b6

連続で走行させてモータカウントがint型の上限を超えることをは低確率であり得るため、検証中に起きた回頭し続ける挙動は、これが原因かもしれない。
また、本タスクの目的ではないが、ライントレース中にモータカウントがオーバーフローした場合は、終了条件を満たしてしまい、即座に次の動作に移ってしまう。


# 変更点
- Measurerにモータカウントを登録するsetCount()関数を追加
- Measurerにモータカウントを0に初期化するresetCount()関数を追加
- AreaMasterがMotionインスタンスをrunする際にresetCount()を呼び出す処理を追加

# 動作テスト
実装後、以下を確認した。
- resetCount()によってモータカウントのオーバーフローを回避できる
- 実装後に走行させ実装前と挙動に変化が見られない