### PR TITLE
close #142 逆回頭補正問題の調査

### DIFF
--- a/module/Motion/CorrectingRotation.cpp
+++ b/module/Motion/CorrectingRotation.cpp
@@ -78,7 +78,8 @@ void CorrectingRotation::run()
   // 補正角度をログに出力
   const int BUF_SIZE = 256;
   char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
-  snprintf(buf, BUF_SIZE, "%d degree angle correction", (int)correctionAngle);
+  snprintf(buf, BUF_SIZE, "%d degree angle correction %s", (int)correctionAngle,
+           isClockwise ? "clockwise" : "anticlockwise");
   logger.log(buf);
 
   // 算出された補正角度だけ回頭する

--- a/rear_camera_py/src/line_angle_calculator.py
+++ b/rear_camera_py/src/line_angle_calculator.py
@@ -167,7 +167,7 @@ class LineAngleCalculator:
     def detect_line_segment(
         self,
         img,
-        length_threshold_mm: int = 62.5,
+        length_threshold_mm: float = 62.5,
         distance_threshold: float = 1.41421356,
         canny_th1: int = 50,
         canny_th2: int = 50,
@@ -181,7 +181,7 @@ class LineAngleCalculator:
 
             NOTE:以下の引数の詳細: https://emotionexplorer.blog.fc2.com/blog-entry-128.html
                                   https://nsr-9.hatenablog.jp/entry/2021/08/12/200000
-            length_threshold_mm (int): 線分を検出する際の長さ閾値(これより短い線は除外)
+            length_threshold_mm (float): 線分を検出する際の長さ閾値(これより短い線は除外)
                                        検出したい線分の長さ = 交点to交点の線分の長さの4分の1（※交点サークル内の距離は除く）
                                                           = 62.5
                                        射影変換によってできた元画像の枠(直線)と同一とみなす距離

--- a/rear_camera_py/src/line_angle_calculator.py
+++ b/rear_camera_py/src/line_angle_calculator.py
@@ -167,8 +167,8 @@ class LineAngleCalculator:
     def detect_line_segment(
         self,
         img,
-        length_threshold_mm: int = 80,
-        distance_threshold: float = 1,
+        length_threshold_mm: int = 62.5,
+        distance_threshold: float = 1.41421356,
         canny_th1: int = 50,
         canny_th2: int = 50,
         canny_aperture_size: int = 7,  # 3~7
@@ -182,8 +182,8 @@ class LineAngleCalculator:
             NOTE:以下の引数の詳細: https://emotionexplorer.blog.fc2.com/blog-entry-128.html
                                   https://nsr-9.hatenablog.jp/entry/2021/08/12/200000
             length_threshold_mm (int): 線分を検出する際の長さ閾値(これより短い線は除外)
-                                       検出したい線分の長さ = 交点to交点の線分の長さの半分（※交点サークル内の距離は除く）
-                                                          = 125
+                                       検出したい線分の長さ = 交点to交点の線分の長さの4分の1（※交点サークル内の距離は除く）
+                                                          = 62.5
                                        射影変換によってできた元画像の枠(直線)と同一とみなす距離
             distance_threshold (float): 距離閾値(この値より遠い座標は、同一線ではない)
                                         1.41421356はcv2.ximgproc.createFastLineDetectorの規定値

--- a/rear_camera_py/src/line_angle_calculator.py
+++ b/rear_camera_py/src/line_angle_calculator.py
@@ -167,8 +167,8 @@ class LineAngleCalculator:
     def detect_line_segment(
         self,
         img,
-        length_threshold_mm: int = 125,
-        distance_threshold: float = 1.41421356,
+        length_threshold_mm: int = 80,
+        distance_threshold: float = 1,
         canny_th1: int = 50,
         canny_th2: int = 50,
         canny_aperture_size: int = 7,  # 3~7


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 追記11/2
- ブロックエリアで使われるコマンドを使用した下記のcsvで、実際に回頭補正が正しく行われるか試した。
- 交点内右折IR(InCrossRight), 交点内左折IL(InCrossleft)の後に回頭補正XRを入れた。
- 経路は下記の画像の通り。(隅の青サークルから左エッジでスタート)
- 結果として、回頭許容誤差を超えたときに、回頭補正が正しく行われた。(下記の動画の通り)
- 左折したら左エッジ、右折したら右エッジになるようにした。（エッジ切替しないと、脱線する）
- length_threshold_mmの値が"125"と"62.5"の時でそれぞれ試したところ、今回の経路ではどちらも問題なかった。
- distance_thresholdの値は規定値の"1.41421356"にしてある。
- length_threshold_mmはとりあえず"62.5"にしておいた。（一応、線分を検出しやすくなったため）
- 線分検出に関しては、黒線が無い方向を走行体のリアカメラが向かない限り、ほぼほぼ検出できる。
- 実際にやってみた感じ、普通はそんなにずれが起きないから、回頭後に毎回補正することはない。
- ずれが起きたとしても、10度前後のずれしか起きないと思われる。
- 逆回頭補正に関しては、あるサークル地点での回頭後の走行体の位置が、あまりにもサークルから遠ざからない限り発生しないと思われる。


【今回使用した実験用のcsvファイルの中身】
```
CC,BLUE,200,-5,0.4,0.12,0.12,青サークルから青サークル
IL,70,200,65,100,交点内移動（左折）
XR,0,100,回頭補正
CC,BLUE,200,-5,0.4,0.12,0.12,青サークルから青サークル
IR,70,200,65,100,交点内移動（右折）
XR,0,100,回頭補正
EC,right,エッジを右に切り替え
CC,GREEN,200,-5,0.4,0.12,0.12,青サークルから緑サークル
IL,70,200,65,100,交点内移動（左折）
XR,0,100,回頭補正
EC,left,エッジを左に切り替え
CC,YELLOW,200,-5,0.33,0.12,0.12,緑サークルから黄サークル
IR,70,200,65,100,交点内移動（右折）
XR,0,100,回頭補正
EC,right,エッジを右に切り替え
CC,YELLOW,200,-5,0.2,0.12,0.12,黄サークルから黄サークル
IS,200,200,交点内移動（直進）
```

![IMG_0744 (1)](https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/7283e6a8-9c4f-438d-b36b-337d1cc18692)
【図1：経路図】

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/8e5ca086-95dc-40fa-9c40-ee62f7371d4a

【動画1：成功した例１】

<img width="570" alt="回頭補正" src="https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/340a0924-a10d-4ada-b3aa-d0d41854f9d0">

【図2：動画1の実行ログ】

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/e60d3f7f-ba1a-4944-b09c-05ca22a45712

【動画2：成功した例２】

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/97c8753f-3f1b-446a-9cc4-a57688328a66

【動画3：エッジ切替しなかった例】

# 変更点
rear_camera_py/src/line_angle_calculator.pyのdetect_line_segment()内のパラメータ値を以下のように変更。
この変更により、より短い線分を検出でき、逆回頭補正が起きない線分を採用することができるようになった。

- 線分を検出する際の長さ閾値length_threshold_mmの値を"125"から"62.5"に変更
- ~仮説線から離れた点を外れ値とみなす距離閾値distance_thresholdの値を"1.41421356"から"1"に変更（この変更はあまり意味がないかも）~[リアカメラシステムテストのエラー原因になった。ここを変える必要はあまりないと思うため、規定値のままにした。]

# 原因調査

- 下の動画のように、逆回頭補正が発生しやすい位置に走行体を置いて回頭補正を何度か行う実験をした。

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/fe265db7-74b7-4e5c-9642-3d4d595191d6

## 実験
- プログラム変更前において、回頭補正が成功する射影変換画像例と、逆回頭補正してしまう射影変換画像例を以下に示す。

![回頭補正が成功する射影変換画像例](https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/e369b918-23ca-46d2-90c6-6cd3295f7368)
【図１： 回頭補正が成功する射影変換画像例】

![逆回頭補正してしまう射影変換画像例](https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/ab32a928-2136-4a63-89c0-03aee7bda0e4)
【図２： 逆回頭補正してしまう射影変換画像例】

- 図1と図2を見てもらうと、図1は下枠に一番近い黒線の手前の線分（エッジ）を検出しており、図2は奥の線分を検出している。この違いが、逆回頭補正が起きるか否かの原因となっていることが実験を通して分かった。

- ちなみに検出される線分の条件は、下枠に一番近い線分かつ、線分とみなす長さ閾値を超えているかである。

- 以上より、閾値を緩めれば図2は図1のように手前の線分を検出することができるのではと考えた。

## 閾値を緩めた結果

- 閾値が交点to交点の線分の長さの半分(=125)であったのを下記のコードのように閾値を緩めた(4分の1にした根拠はないが、ブロックの横幅よりは長くするようにした)ところ、完全に図2と同じではないが下図3の似たような射影変換画像において、図1のように一番近い線分を検出することが出来た。

```suggestion
検出したい線分の長さ = 交点to交点の線分の長さの4分の1（※交点サークル内の距離は除く）
                                      = 62.5
```

![閾値を緩めたときの射影変換画像例](https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/128010851/dedfcf63-b38f-44a3-b9ce-5274c146cae2)
【図３： 図2のような射影変換画像において回頭補正が成功する例】

## 懸念点

- どこまで閾値を緩めるべきか（緩めすぎると、誤ってブロックの線分を検出してしまうのではないか）
　⇒　どの程度までなら影響が出ないか、閾値調整しながら様々なパターン(ブロックが写る場合など)で回頭補正を試す
　⇒　実際にブロックエリア内を走行させて、実際の回頭後に回頭補正が正しく機能するか試す

- 閾値を緩める解決策が上手くいかない場合に、どうすべきか
　⇒　線分検出したり、走行体と黒線の為す角（計測角度）を求めたりするpython側と、pythonから計測角度を受け取って補正角度を算出するc++側のコードを上手く修正する

## 調査しておいた方がいいこと

- 回頭補正が失敗する箇所（線分を検出できない or 逆回頭補正してしまう）を調査する

# 補足資料

- 下記に今回のタスクでの回頭補正画像等を上げてます。
https://drive.google.com/drive/folders/1-niEQvMF1wmWS2j6e61-WhNTh2OWwlt0?usp=drive_link

- 線分検出のパラメータの詳細については下記のサイトを参考にしてください。
https://docs.hsp.moe/OpenCV/453/cpp/ja/group__ximgproc__fast__line__detector.html