### PR TITLE
close #139 ブロックエリアにおける経路探索と対応コマンドの生成

### DIFF
--- a/rear_camera_py/src/block_area_map.py
+++ b/rear_camera_py/src/block_area_map.py
@@ -1,0 +1,33 @@
+"""ブロックエリアのマップを定義するクラス(経路探索用).
+
+@author: miyashita64 YKhm20020
+"""
+
+import numpy as np
+
+
+class BlockAreaMap:
+    """ブロックエリアのマップを定義するクラス."""
+
+    L_COURSE_CIRCLE_COLOR_MAP = np.array([
+        ["RED", "RED", "YELLOW", "YELLOW"],
+        ["RED", "RED", "YELLOW", "YELLOW"],
+        ["BLUE", "BLUE", "GREEN", "GREEN"],
+        ["BLUE", "BLUE", "GREEN", "GREEN"]
+    ])
+
+    def __init__(self, is_left_course, block_map):
+        """コンストラクタ.
+
+        Args:
+            is_left_course (bool): Lコースであるかどうか
+            block_map (np.array): コース情報
+        """
+        self.block_map = block_map
+
+        # L/Rに合わせてサークルの色を設定
+        if is_left_course:
+            self.circle_color_map = BlockAreaMap.L_COURSE_CIRCLE_COLOR_MAP
+        else:
+            # x軸(第2のインデックス)を反転
+            self.circle_color_map = BlockAreaMap.L_COURSE_CIRCLE_COLOR_MAP[:, ::-1]

--- a/rear_camera_py/src/block_area_map.py
+++ b/rear_camera_py/src/block_area_map.py
@@ -25,6 +25,11 @@ class BlockAreaMap:
         """
         self.block_map = block_map
 
+        # ブロックの座標のリスト
+        block_coords = np.transpose(np.nonzero(self.block_map))
+        # 型をタプルに統一する
+        self.block_coords = [tuple(coord) for coord in block_coords]
+
         # L/Rに合わせてサークルの色を設定
         if is_left_course:
             self.circle_color_map = BlockAreaMap.L_COURSE_CIRCLE_COLOR_MAP

--- a/rear_camera_py/src/block_de_treasure_hunter.py
+++ b/rear_camera_py/src/block_de_treasure_hunter.py
@@ -1,0 +1,63 @@
+"""ブロックdeトレジャーハンター攻略クラス.
+
+@author: miyashita64 YKhm20020
+"""
+
+import numpy as np
+from block_area_map import BlockAreaMap
+from navigator import Navigator
+from robot import Robot, Direction
+from motion import Motion
+
+
+class BlockDeTreasureHunter:
+    """ブロックdeトレジャーを攻略するクラス."""
+
+    def hunt(self, is_left_course):
+        """攻略を実行する.
+
+        Args:
+            is_left_course (bool): Lコースであるかどうか
+        """
+        # コース情報取得
+        # TODO: ここから、マージする際に差し替える
+        length = 4
+        block_map = np.zeros((length, length))
+        dummy_block_coords = [(0, 3), (3, 3)]
+        treasure_block_coord = (3, 0)
+        for (y, x) in dummy_block_coords:
+            block_map[y][x] = 1
+        block_map[treasure_block_coord[0], treasure_block_coord[1]] = 2
+        # TODO: ここまで、マージする際に差し替える
+        print(block_map)
+
+        # ブロックエリアのマップ初期化
+        block_area_map = BlockAreaMap(is_left_course, block_map)
+        # ナビゲーター初期化
+        navigator = Navigator(block_area_map)
+
+        # L/Rに合わせて開始・終了状態を設定(Lコースを基準)
+        start_direction = Direction.N
+        end_direction = Direction.E
+        start_coord = (2, 0)
+        end_coord = (1, 3)
+        if not is_left_course:
+            # Rコースの場合
+            end_direction = Direction.W
+            start_coord = (2, 3)
+            end_coord = (1, 0)
+        # ロボット初期化
+        start_robot = Robot(*start_coord, start_direction,
+                            [Motion(
+                                {"comment": f"start = ({start_coord[0]} {start_coord[1]} \
+                                     {start_direction.name})"})])
+        end_robot = Robot(*end_coord, end_direction)
+
+        # 動作を計画する
+        navigator.navigate(start_robot, end_robot)
+
+
+if __name__ == "__main__":
+    is_left_course = True
+    hunter = BlockDeTreasureHunter()
+    hunter.hunt(is_left_course)

--- a/rear_camera_py/src/block_de_treasure_hunter.py
+++ b/rear_camera_py/src/block_de_treasure_hunter.py
@@ -3,6 +3,7 @@
 @author: miyashita64 YKhm20020
 """
 
+import sys
 import numpy as np
 from block_area_map import BlockAreaMap
 from navigator import Navigator
@@ -57,6 +58,13 @@ class BlockDeTreasureHunter:
 
 
 if __name__ == "__main__":
-    is_left_course = True
-    hunter = BlockDeTreasureHunter()
-    hunter.hunt(is_left_course)
+    args = sys.argv
+    if 2 <= len(args):
+        if args[1] == "true" or args[1] == "false":
+            is_left_course = args[1] == "true"
+            hunter = BlockDeTreasureHunter()
+            hunter.hunt(is_left_course)
+        else:
+            print("An invalid argument was given.")
+    else:
+        print("The argument is_left_course was not given.")

--- a/rear_camera_py/src/block_de_treasure_hunter.py
+++ b/rear_camera_py/src/block_de_treasure_hunter.py
@@ -68,8 +68,8 @@ class BlockDeTreasureHunter:
 if __name__ == "__main__":
     args = sys.argv
     if 2 <= len(args):
-        if args[1] == "true" or args[1] == "false":
-            is_left_course = args[1] == "true"
+        if args[1] == "left" or args[1] == "right":
+            is_left_course = args[1] == "left"
             hunter = BlockDeTreasureHunter()
             hunter.hunt(is_left_course)
         else:

--- a/rear_camera_py/src/block_de_treasure_hunter.py
+++ b/rear_camera_py/src/block_de_treasure_hunter.py
@@ -23,7 +23,7 @@ class BlockDeTreasureHunter:
         # TODO: ここから、マージする際に差し替える
         length = 4
         block_map = np.zeros((length, length))
-        dummy_block_coords = [(2, 0), (1, 3)]
+        dummy_block_coords = [(3, 3), (0, 3)]
         treasure_block_coord = (0, 0)
         for (y, x) in dummy_block_coords:
             block_map[y][x] = 1

--- a/rear_camera_py/src/block_de_treasure_hunter.py
+++ b/rear_camera_py/src/block_de_treasure_hunter.py
@@ -54,7 +54,15 @@ class BlockDeTreasureHunter:
         end_robot = Robot(*end_coord, end_direction)
 
         # 動作を計画する
-        navigator.navigate(start_robot, end_robot)
+        robot = navigator.navigate(start_robot, end_robot)
+        # コマンドを出力する
+        commands = ""
+        for motion in robot.motions:
+            commands += f"{motion.make_command()}\n"
+        # TODO: ブロックdeトレジャーハンター攻略の詳細が決まり次第パスを設定しなおす
+        # 既存のコマンドファイルを書き換えたくないので、Left/Rightはあえて入れていません。
+        with open("../../datafiles/BlockDeTreasure.csv", "w") as f:
+            f.write(commands)
 
 
 if __name__ == "__main__":

--- a/rear_camera_py/src/block_de_treasure_hunter.py
+++ b/rear_camera_py/src/block_de_treasure_hunter.py
@@ -23,8 +23,8 @@ class BlockDeTreasureHunter:
         # TODO: ここから、マージする際に差し替える
         length = 4
         block_map = np.zeros((length, length))
-        dummy_block_coords = [(0, 3), (3, 3)]
-        treasure_block_coord = (3, 0)
+        dummy_block_coords = [(2, 0), (1, 3)]
+        treasure_block_coord = (0, 0)
         for (y, x) in dummy_block_coords:
             block_map[y][x] = 1
         block_map[treasure_block_coord[0], treasure_block_coord[1]] = 2
@@ -47,10 +47,9 @@ class BlockDeTreasureHunter:
             start_coord = (2, 3)
             end_coord = (1, 0)
         # ロボット初期化
+        comment = f"start = ({start_coord[0]} {start_coord[1]} {start_direction.name})"
         start_robot = Robot(*start_coord, start_direction,
-                            [Motion(
-                                {"comment": f"start = ({start_coord[0]} {start_coord[1]} \
-                                     {start_direction.name})"})])
+                            [Motion({"comment": comment})])
         end_robot = Robot(*end_coord, end_direction)
 
         # 動作を計画する

--- a/rear_camera_py/src/motion.py
+++ b/rear_camera_py/src/motion.py
@@ -26,6 +26,20 @@ class Motion:
             command += f"{self.params[key]}, "
         return command
 
+    @staticmethod
+    def calc_rotate_angle(target_real_angle) -> int:
+        """回頭角度に対する指定角度を返す.
+
+        Args:
+            target_real_angle (int): 実際に回頭したい角度
+        Returns:
+            target_rotate_angle (int): 回頭に指定する角度
+        """
+        # TODO: 要調整
+        # (暫定で、90度を指定されたときに60を返すようにしている(過去のコマンドファイル参照))
+        target_rotate_angle = target_real_angle * 2 / 3
+        return target_rotate_angle
+
 
 class Straight(Motion):
     """交点の直進動作."""
@@ -64,7 +78,7 @@ class Curve(Motion):
             "command": "IR" if angle > 0 else "IL",
             "straight_distance": 65.0,
             "straight_speed": 200,
-            "rotation_angle": abs(angle),
+            "rotation_angle": Motion.calc_rotate_angle(abs(angle)),
             "rotation_pwm": 100,
             "comment": comment,
         }

--- a/rear_camera_py/src/motion.py
+++ b/rear_camera_py/src/motion.py
@@ -34,7 +34,7 @@ class Straight(Motion):
         """コンストラクタ.
 
         Args:
-            color (str): 直進でライントレースする際に目標とする色
+            color (str): 交点サークルまでライントレースする際に目標とする色
             comment (str): 動作のコメント
         """
         self.params = {

--- a/rear_camera_py/src/motion.py
+++ b/rear_camera_py/src/motion.py
@@ -1,0 +1,71 @@
+"""ロボットの動作クラス(経路探索用).
+
+@author: miyashita64 YKhm20020
+"""
+
+
+class Motion:
+    """ロボットの動作を表わすクラス."""
+
+    def __init__(self, params):
+        """コンストラクタ.
+
+        Args:
+            params ([key: value]): 動作のパラメータ
+        """
+        self.params = params
+
+    def make_command(self) -> str:
+        """この動作を表わすコマンドを返す.
+
+        Returns:
+            command (str): 動作コマンド
+        """
+        command = ""
+        for key in self.params:
+            command += f"{self.params[key]}, "
+        return command
+
+
+class Straight(Motion):
+    """交点の直進動作."""
+
+    def __init__(self, color, comment=""):
+        """コンストラクタ.
+
+        Args:
+            color (str): 直進でライントレースする際に目標とする色
+            comment (str): 動作のコメント
+        """
+        self.params = {
+            "command": "CC",
+            "line_trace_color": color,
+            "line_trace_speed": 200,
+            "line_trace_brightness": -10,
+            "line_trace_kp": 0.33,
+            "line_trace_ki": 0.12,
+            "line_trace_kd": 0.12,
+            "comment": comment,
+        }
+        self.cost = 30  # TODO: 実際にかかる時間を計測する
+
+
+class Curve(Motion):
+    """交点の右左折動作."""
+
+    def __init__(self, angle, comment=""):
+        """コンストラクタ.
+
+        Args:
+            angle (int): 回頭角度[deg]
+            comment (str): 動作のコメント
+        """
+        self.params = {
+            "command": "IR" if angle > 0 else "IL",
+            "straight_distance": 65.0,
+            "straight_speed": 200,
+            "rotation_angle": abs(angle),
+            "rotation_pwm": 100,
+            "comment": comment,
+        }
+        self.cost = 5 + abs(angle)  # TODO: 実際にかかる時間を計測する

--- a/rear_camera_py/src/navigator.py
+++ b/rear_camera_py/src/navigator.py
@@ -83,7 +83,7 @@ class Navigator:
                 robot.motions.append(Motion({
                     "command": "PR",
                     "pwm": 75,
-                    "angle": abs(angle_diff),
+                    "angle": Motion.calc_rotate_angle(abs(angle_diff)),
                     "direction": "clockwise" if angle_diff > 0 else "anticlockwise",
                     "comment": f"({robot.y} {robot.x} {robot.direction.name})",
                 }))

--- a/rear_camera_py/src/navigator.py
+++ b/rear_camera_py/src/navigator.py
@@ -1,0 +1,126 @@
+"""経路探索クラス.
+
+@author: miyashita64 YKhm20020
+"""
+
+import numpy as np
+from robot import Robot, Direction
+from block_area_map import BlockAreaMap
+from motion import Motion
+
+
+class Navigator:
+    """経路探索するクラス."""
+
+    def __init__(self, block_area_map):
+        """コンストラクタ.
+
+        Args:
+            block_area_map (BlockAreaMap): ブロックエリアのマップ
+        """
+        self.block_area_map = block_area_map
+
+    def calculate_distance(self, start_coord, target_coord):
+        """2点間のユークリッド距離を計算する.
+
+        Args:
+            start_coord ((int, int)): 初期地点
+            target_coord ((int, int)): 対象ブロックの座標
+
+        Returns:
+            distance (double): 2点間のユークリッド距離
+        """
+        x1, y1 = start_coord
+        x2, y2 = target_coord
+        distance = ((x1 - x2) ** 2 + (y1 - y2) ** 2) ** 0.5
+        return distance
+
+    def decide_blocks_order(self, start_coord) -> [(int, int)]:
+        """ブロックの運搬順序を決定する.
+
+        Args:
+            start_coord ((int,int)): スタート座標
+
+        Returns:
+            block_order([(int, int)]): 運ぶ順にソートしたブロックの座標のリスト
+        """
+        # ブロックの座標のリスト
+        block_coords = np.transpose(np.nonzero(self.block_area_map.block_map))
+        # 型をタプルに統一する
+        block_coords = [tuple(coord) for coord in block_coords]
+
+        # 距離が近い順にブロックに向かう（色の区別なし）
+        block_order = sorted(
+            block_coords, key=lambda coord: self.calculate_distance(start_coord, coord))
+
+        return block_order
+
+    def simulate_route(self, initial_robot, target_coord) -> Robot:
+        """ロボットが目標座標に移動するための経路を算出する.
+
+        Args:
+            initial_robot (Robot): ロボットの初期状態
+            target_coord (int, int): 目標座標
+        Returns:
+            (Robot): 探索終了時のロボット
+        """
+        open_list = [initial_robot]
+        close_list = []
+
+        while len(open_list) > 0:
+            # 最有力な探索対象を取り出し
+            current_robot = open_list.pop(0)
+            # 目標座標に行き着いた場合、探索終了
+            if current_robot.get_coord() == target_coord:
+                return current_robot
+            # 遷移可能なロボットの状態を探索対象に追加
+            open_list += current_robot.get_transitionable_robots(
+                self.block_area_map.circle_color_map
+            )
+            # 探索済みの状態を記録
+            close_list += [current_robot]
+            # 重複している or 探索終了済みのロボットの状態を除去
+            open_list = list(set(open_list) - set(close_list))
+            # 実コストでソートする
+            open_list = sorted(open_list)
+
+        # 経路未発見
+        print("\nFailed simulate.\n")
+        return None
+
+    def navigate(self, start_robot, end_robot) -> None:
+        """ロボットの動作を計画する.
+
+        Args:
+            start_robot (Robot): ロボットの開始状態
+            end_robot (Robot): ロボットの終了状態
+        """
+        # ブロックの運搬順を決定
+        block_order = self.decide_blocks_order(start_robot.get_coord())
+
+        # ロボットの初期化
+        robot = start_robot
+        # ブロック毎に経路探索
+        for block_coord in block_order:
+            robot = self.simulate_route(robot, block_coord)
+            # 探索に失敗した場合
+            if robot is None:
+                # 動作ファイルを書き換えずに処理を終了(デフォルトのファイルが使用されるはず)
+                exit()
+        # 終了状態の座標への経路探索
+        robot = self.simulate_route(robot, end_robot.get_coord())
+        # 終了状態に方角を合わせる
+        angle_diff = end_robot.direction - robot.direction
+        if angle_diff:
+            robot.direction = end_robot.direction
+            robot.motions.append(Motion({
+                "command": "PR",
+                "pwm": 75,
+                "angle": abs(angle_diff),
+                "direction": "clockwise" if angle_diff > 0 else "anticlockwise",
+                "comment": f"({robot.y} {robot.x} {robot.direction.name})",
+            }))
+
+        # コマンドを出力する
+        for motion in robot.motions:
+            print(motion.make_command())

--- a/rear_camera_py/src/navigator.py
+++ b/rear_camera_py/src/navigator.py
@@ -54,12 +54,14 @@ class Navigator:
         print("\nFailed simulate.\n")
         return None
 
-    def navigate(self, start_robot, end_robot) -> None:
+    def navigate(self, start_robot, end_robot) -> Robot:
         """ロボットの動作を計画する.
 
         Args:
             start_robot (Robot): ロボットの開始状態
             end_robot (Robot): ロボットの終了状態
+        Returns:
+            best_robot (Robot): 最適な経路を走行したロボットの状態
         """
         robots = []
         # ブロックの運搬順の全ての組み合わせについて繰り返す
@@ -88,8 +90,6 @@ class Navigator:
                 }))
             robots += [robot]
 
-        # 動作コストが最も小さいロボットを抽出
+        # 動作コストが最も小さいロボットを返す
         best_robot = sorted(robots)[0]
-        # コマンドを出力する
-        for motion in best_robot.motions:
-            print(motion.make_command())
+        return best_robot

--- a/rear_camera_py/src/navigator.py
+++ b/rear_camera_py/src/navigator.py
@@ -30,25 +30,23 @@ class Navigator:
         Returns:
             (Robot): 探索終了時のロボット
         """
-        open_list = [initial_robot]
-        close_list = []
+        simulatable_robots = [initial_robot] # 探索候補のロボットの状態
+        simulated_robots = []                # 探索済みのロボット状態
 
-        while len(open_list) > 0:
-            # 最有力な探索対象を取り出し
-            current_robot = open_list.pop(0)
+        while len(simulatable_robots) > 0:
+            # コストが最小な探索対象
+            robot = min(simulatable_robots)
             # 目標座標に行き着いた場合、探索終了
-            if current_robot.get_coord() == target_coord:
-                return current_robot
+            if robot.get_coord() == target_coord:
+                return robot
             # 遷移可能なロボットの状態を探索対象に追加
-            open_list += current_robot.get_transitionable_robots(
+            simulatable_robots += robot.get_transitionable_robots(
                 self.block_area_map.circle_color_map
             )
             # 探索済みの状態を記録
-            close_list += [current_robot]
-            # 重複している or 探索終了済みのロボットの状態を除去
-            open_list = list(set(open_list) - set(close_list))
-            # 実コストでソートする
-            open_list = sorted(open_list)
+            simulated_robots += [robot]
+            # 集合として、重複している or 探索済みのロボットの状態を除去
+            simulatable_robots = list(set(simulatable_robots) - set(simulated_robots))
 
         # 経路未発見
         print("\nFailed simulate.\n")
@@ -81,6 +79,7 @@ class Navigator:
             angle_diff = end_robot.direction - robot.direction
             if angle_diff:
                 robot.direction = end_robot.direction
+                # 回頭動作を追加
                 robot.motions.append(Motion({
                     "command": "PR",
                     "pwm": 75,
@@ -91,5 +90,5 @@ class Navigator:
             robots += [robot]
 
         # 動作コストが最も小さいロボットを返す
-        best_robot = sorted(robots)[0]
+        best_robot = min(robots)
         return best_robot

--- a/rear_camera_py/src/navigator.py
+++ b/rear_camera_py/src/navigator.py
@@ -4,6 +4,7 @@
 """
 
 import numpy as np
+from itertools import permutations
 from robot import Robot, Direction
 from block_area_map import BlockAreaMap
 from motion import Motion
@@ -19,41 +20,6 @@ class Navigator:
             block_area_map (BlockAreaMap): ブロックエリアのマップ
         """
         self.block_area_map = block_area_map
-
-    def calculate_distance(self, start_coord, target_coord):
-        """2点間のユークリッド距離を計算する.
-
-        Args:
-            start_coord ((int, int)): 初期地点
-            target_coord ((int, int)): 対象ブロックの座標
-
-        Returns:
-            distance (double): 2点間のユークリッド距離
-        """
-        x1, y1 = start_coord
-        x2, y2 = target_coord
-        distance = ((x1 - x2) ** 2 + (y1 - y2) ** 2) ** 0.5
-        return distance
-
-    def decide_blocks_order(self, start_coord) -> [(int, int)]:
-        """ブロックの運搬順序を決定する.
-
-        Args:
-            start_coord ((int,int)): スタート座標
-
-        Returns:
-            block_order([(int, int)]): 運ぶ順にソートしたブロックの座標のリスト
-        """
-        # ブロックの座標のリスト
-        block_coords = np.transpose(np.nonzero(self.block_area_map.block_map))
-        # 型をタプルに統一する
-        block_coords = [tuple(coord) for coord in block_coords]
-
-        # 距離が近い順にブロックに向かう（色の区別なし）
-        block_order = sorted(
-            block_coords, key=lambda coord: self.calculate_distance(start_coord, coord))
-
-        return block_order
 
     def simulate_route(self, initial_robot, target_coord) -> Robot:
         """ロボットが目標座標に移動するための経路を算出する.
@@ -95,32 +61,35 @@ class Navigator:
             start_robot (Robot): ロボットの開始状態
             end_robot (Robot): ロボットの終了状態
         """
-        # ブロックの運搬順を決定
-        block_order = self.decide_blocks_order(start_robot.get_coord())
+        robots = []
+        # ブロックの運搬順の全ての組み合わせについて繰り返す
+        for block_order in permutations(self.block_area_map.block_coords):
+            # ロボットの初期化
+            robot = start_robot
+            # ブロック毎に経路探索
+            for block_coord in block_order:
+                robot = self.simulate_route(robot, block_coord)
+                # 探索に失敗した場合
+                if robot is None:
+                    # 動作ファイルを書き換えずに処理を終了(デフォルトのファイルが使用されるはず)
+                    exit()
+            # 終了状態の座標への経路探索
+            robot = self.simulate_route(robot, end_robot.get_coord())
+            # 終了状態に方角を合わせる
+            angle_diff = end_robot.direction - robot.direction
+            if angle_diff:
+                robot.direction = end_robot.direction
+                robot.motions.append(Motion({
+                    "command": "PR",
+                    "pwm": 75,
+                    "angle": abs(angle_diff),
+                    "direction": "clockwise" if angle_diff > 0 else "anticlockwise",
+                    "comment": f"({robot.y} {robot.x} {robot.direction.name})",
+                }))
+            robots += [robot]
 
-        # ロボットの初期化
-        robot = start_robot
-        # ブロック毎に経路探索
-        for block_coord in block_order:
-            robot = self.simulate_route(robot, block_coord)
-            # 探索に失敗した場合
-            if robot is None:
-                # 動作ファイルを書き換えずに処理を終了(デフォルトのファイルが使用されるはず)
-                exit()
-        # 終了状態の座標への経路探索
-        robot = self.simulate_route(robot, end_robot.get_coord())
-        # 終了状態に方角を合わせる
-        angle_diff = end_robot.direction - robot.direction
-        if angle_diff:
-            robot.direction = end_robot.direction
-            robot.motions.append(Motion({
-                "command": "PR",
-                "pwm": 75,
-                "angle": abs(angle_diff),
-                "direction": "clockwise" if angle_diff > 0 else "anticlockwise",
-                "comment": f"({robot.y} {robot.x} {robot.direction.name})",
-            }))
-
+        # 動作コストが最も小さいロボットを抽出
+        best_robot = sorted(robots)[0]
         # コマンドを出力する
-        for motion in robot.motions:
+        for motion in best_robot.motions:
             print(motion.make_command())

--- a/rear_camera_py/src/robot.py
+++ b/rear_camera_py/src/robot.py
@@ -1,0 +1,147 @@
+"""ロボットの状態を保持するクラス(経路探索用).
+
+@author: miyashita64 YKhm20020
+"""
+
+from enum import Enum
+from motion import Motion, Straight, Curve
+from block_area_map import BlockAreaMap
+
+
+class Robot:
+    """ロボットの状態を保持するクラス."""
+
+    def __init__(self, y, x, direction, motions=[], cost=0):
+        """コンストラクタ.
+
+        Args:
+            y (int): ロボットのマップ上のy座標
+            x (int): ロボットのマップ上のx座標
+            direction (Direction): ロボットの向く方角(進行方向)
+            motions ([Motion]): この状態に遷移するための動作のリスト
+            cost (int): 動作のリストの総コスト
+        """
+        self.y = y
+        self.x = x
+        self.direction = direction
+        self.motions = motions
+        self.cost = cost
+
+    def __hash__(self) -> int:
+        """ロボットの状態に対しユニークな値を返す.
+
+        Returns:
+            (int): 座標,方角,コストを用いたハッシュ値
+        """
+        return hash(self.y + self.x * 10 + self.direction.value * 100 + self.cost * 1000)
+
+    def __eq__(self, other) -> bool:
+        """同値(==)の定義.
+
+        Args:
+            other (Robot): 比較対象のロボット
+        Returns:
+            (bool): 2つのRobotが同値であるかどうか
+        """
+        # 座標、方角、コストが同じであることを同じRobotであることの条件とする.
+        return self.y == other.y and self.x == other.x \
+            and self.direction == other.direction \
+            and self.cost == other.cost
+
+    def __lt__(self, other) -> None:
+        """より小さい(self < other)の定義.
+
+        Args:
+            other (Robot): 比較対象のロボット
+        Returns:
+            (bool): self < other かどうか
+        """
+        return self.cost < other.cost
+
+    def get_coord(self) -> (int, int):
+        """自身の座標を返す.
+
+        Returns:
+            y (int): ロボットのマップ上のy座標
+            x (int): ロボットのマップ上のx座標
+        """
+        return (self.y, self.x)
+
+    def get_transitionable_robots(self, circle_color_map):
+        """一つの動作で遷移可能なロボットの状態のリストを返す.
+
+        Args:
+            circle_color_map ([[str]]): マップ上のサークルの色
+        Returns:
+            transitionable_robots ([Robot]): 遷移可能なロボットのリスト
+        """
+        transitionable_robots = []
+        max_y, max_x, *_ = circle_color_map.shape
+        # 各方角に対する動作について
+        for direct in Direction:
+            if direct == self.direction:
+                # 進行方向の方角については、前進することを考慮する
+                forward_y, forward_x = self.get_forward_coord()
+                # 座標がマップ外であれば
+                if forward_y < 0 or max_y <= forward_y \
+                        or forward_x < 0 or max_x <= forward_x:
+                    continue
+                color = circle_color_map[forward_y][forward_x]
+                comment = f"({forward_y} {forward_x} {self.direction.name})"
+                motion = Straight(color, comment)
+                next_robot = Robot(forward_y, forward_x, self.direction,
+                                   self.motions + [motion], self.cost + motion.cost)
+            else:
+                # 進行方向以外の方角については、方角を変えることを考慮する
+                rotation_angle = direct - self.direction
+                comment = f"({self.y} {self.x} {direct.name})"
+                motion = Curve(rotation_angle, comment)
+                next_robot = Robot(self.y, self.x, direct,
+                                   self.motions + [motion], self.cost + motion.cost)
+            # 1つの動作を追加したロボットの状態を保持する
+            transitionable_robots += [next_robot]
+        return transitionable_robots
+
+    def get_forward_coord(self) -> (int, int):
+        """進行方向に進んだ座標を返す.
+
+        Returns:
+            forward_y (int): 進行方向に進んだ場合のy座標
+            forward_x (int): 進行方向に進んだ場合のx座標
+        """
+        forward_y = self.y
+        forward_x = self.x
+        if self.direction == Direction.N:
+            forward_y -= 1
+        elif self.direction == Direction.S:
+            forward_y += 1
+        elif self.direction == Direction.E:
+            forward_x += 1
+        elif self.direction == Direction.W:
+            forward_x -= 1
+        return forward_y, forward_x
+
+
+class Direction(Enum):
+    """方角を保持するクラス."""
+
+    N = 0     # 北
+    E = 1     # 東
+    S = 2     # 南
+    W = 3     # 西
+
+    def __sub__(self, other) -> int:
+        """差(-)の定義.
+
+        Returns:
+            angle (int): 方角間の角度の差
+        """
+        diff = (self.value - other.value) % len(Direction)
+        # 方角の差が180度以下相当の場合
+        if diff <= len(Direction) / 2:
+            # 右回り
+            angle = diff * 360 / len(Direction)
+        else:
+            # 左周り
+            angle = (diff - len(Direction)) * 360 / len(Direction)
+        return angle

--- a/rear_camera_py/src/robot.py
+++ b/rear_camera_py/src/robot.py
@@ -67,6 +67,25 @@ class Robot:
         """
         return (self.y, self.x)
 
+    def get_forward_coord(self) -> (int, int):
+        """進行方向に進んだ座標を返す.
+
+        Returns:
+            forward_y (int): 進行方向に進んだ場合のy座標
+            forward_x (int): 進行方向に進んだ場合のx座標
+        """
+        forward_y = self.y
+        forward_x = self.x
+        if self.direction == Direction.N:
+            forward_y -= 1
+        elif self.direction == Direction.S:
+            forward_y += 1
+        elif self.direction == Direction.E:
+            forward_x += 1
+        elif self.direction == Direction.W:
+            forward_x -= 1
+        return forward_y, forward_x
+
     def get_transitionable_robots(self, circle_color_map):
         """一つの動作で遷移可能なロボットの状態のリストを返す.
 
@@ -102,25 +121,6 @@ class Robot:
             transitionable_robots += [next_robot]
         return transitionable_robots
 
-    def get_forward_coord(self) -> (int, int):
-        """進行方向に進んだ座標を返す.
-
-        Returns:
-            forward_y (int): 進行方向に進んだ場合のy座標
-            forward_x (int): 進行方向に進んだ場合のx座標
-        """
-        forward_y = self.y
-        forward_x = self.x
-        if self.direction == Direction.N:
-            forward_y -= 1
-        elif self.direction == Direction.S:
-            forward_y += 1
-        elif self.direction == Direction.E:
-            forward_x += 1
-        elif self.direction == Direction.W:
-            forward_x -= 1
-        return forward_y, forward_x
-
 
 class Direction(Enum):
     """方角を保持するクラス."""
@@ -136,6 +136,7 @@ class Direction(Enum):
         Returns:
             angle (int): 方角間の角度の差
         """
+        # 方角の差(右回り換算)
         diff = (self.value - other.value) % len(Direction)
         # 方角の差が180度以下相当の場合
         if diff <= len(Direction) / 2:


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- ブロックの位置情報を入力として、ブロックを通るような経路を実現する動作を探索するクラス群を追加した


# 方針

## 攻略手順の想定

1. BlockDeTreasureHunterクラスが[ブロックエリアのエリア情報取得 ](https://github.com/KatLab-MiyazakiUniv/etrobocon2023/issues/135)を呼び出し、ブロックがある座標には1 or 2、それ以外には0が入ったnumpy配列を生成する
2. 1.のnumpy配列からBlockAreaMapクラスを生成し、座標に対するブロックの有無とサークルの色を管理する
3. NavigatorクラスはBlockAreaMapを基に、ロボットの状態(Robotクラス)をノードとして探索する。
4. 探索では、Robotクラスが持つその状態になるための動作(Motion)のリストの合計コストを実コストとして扱い、コストが小さい順に、次になりえるロボットの状態を探索する。予測コストは用いない。

## ブロックの運搬順序
- 全てのブロックの運搬順序について探索し、最も動作コストが安いものを選択する
- トレジャーブロックとダミーブロックは区別しない

## 探索時の動作の決定方法
現在仮置きで生成している。今後の調整次第で動作やそのコストは変動するはず。
- 交差点を直進する場合はCC動作を呼び出す
- 交差点を左折する場合はIL動作を呼び出す
- 交差点を右折もしくは180回頭する場合はIR動作を呼び出す

# 動作テスト
HTMLでビューワーを実装し意図しない経路がないことを確認した。
※ビューワーは各動作コマンドの末尾にあるコメントを基に、探索した経路を描画しています。経路に対する具体的な動作は、次回以降のタスクの範疇だと思っています。

例１

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/83441177/6002ad3c-7bad-4dfa-b078-ac577b5080a9

例２

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/83441177/d604fe89-57d9-4094-a720-07125c0d87de

例３

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/83441177/b0c1f4ea-b28e-4b3e-8850-6aa925ca7903

開始・終了点にブロックがある場合

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/83441177/70c72d74-e0a1-40ce-bf04-ce1b46917f05

Rコースの例(ビューワーでは対応していませんが、本来サークルの色はy軸に対して線対称に反転します)

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/83441177/45f9a938-425b-4dbe-9138-4598b94588f6
