### PR TITLE
close #140 ブロック移動のためのコマンド・動作

### DIFF
--- a/module/API/Measurer.cpp
+++ b/module/API/Measurer.cpp
@@ -55,7 +55,7 @@ void Measurer::setRightCount(int count)
   rightMotor->setCount(count);
 }
 
-// モータ角位置の初期化
+// 左右モータ角位置の初期化
 void Measurer::resetCount()
 {
   Measurer::setLeftCount(0);
@@ -66,6 +66,18 @@ void Measurer::resetCount()
 int Measurer::getArmMotorCount()
 {
   return armMotor->getCount();
+}
+
+// アームモータ角位置更新
+void Measurer::setArmMotorCount(int count)
+{
+  return armMotor->setCount(count);
+}
+
+// アームモータ角位置の初期化
+void Measurer::resetArmMotorCount()
+{
+  return armMotor->setCount(0);
 }
 
 // 正面から見て左ボタンの押下状態を取得

--- a/module/API/Measurer.h
+++ b/module/API/Measurer.h
@@ -73,12 +73,12 @@ class Measurer {
   /**
    * アームモータ角位置を更新
    */
-  void setArmMotorCount(int count);
+  static void setArmMotorCount(int count);
 
   /**
    * アームモータ角位置を初期化
    */
-  void resetArmMotorCount();
+  static void resetArmMotorCount();
 
   /**
    * 正面から見て左ボタンの押下状態を取得

--- a/module/API/Measurer.h
+++ b/module/API/Measurer.h
@@ -60,7 +60,7 @@ class Measurer {
   static void setRightCount(int count);
 
   /**
-   * モータ角位置を初期化
+   * 左右モータ角位置を初期化
    */
   static void resetCount();
 
@@ -69,6 +69,16 @@ class Measurer {
    * @return アームモータ角位置[deg]
    */
   static int getArmMotorCount();
+
+  /**
+   * アームモータ角位置を更新
+   */
+  void setArmMotorCount(int count);
+
+  /**
+   * アームモータ角位置を初期化
+   */
+  void resetArmMotorCount();
 
   /**
    * 正面から見て左ボタンの押下状態を取得

--- a/module/Motion/ArmMotion.cpp
+++ b/module/Motion/ArmMotion.cpp
@@ -1,0 +1,85 @@
+/**
+ * @file   ArmMotion.cpp
+ * @brief  アーム動作クラス
+ * @author KakinokiKanta
+ */
+
+#include "ArmMotion.h"
+
+using namespace std;
+
+ArmMotion::ArmMotion(int _angle, int _pwm) : angle(_angle), pwm(_pwm) {}
+
+void ArmMotion::run()
+{
+  int initCount = Measurer::getArmMotorCount();
+
+  const int BUF_SIZE = 128;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+
+  // pwm値が0以下の場合はwarningを出して終了する
+  if(pwm <= 0) {
+    snprintf(buf, BUF_SIZE, "The pwm value passed to ArmMotion is %d", pwm);
+    logger.logWarning(buf);
+    return;
+  }
+
+  // pwmが40より大きい場合はwarningを出してpwmを40にする
+  if(pwm > 40) {
+    snprintf(buf, BUF_SIZE, "The pwm value passed to ArmMotion is %d", pwm);
+    logger.logWarning(buf);
+    pwm = 40;
+  }
+
+  // angleが0の場合はwarningを出して終了する
+  if(angle == 0) {
+    snprintf(buf, BUF_SIZE, "The angle value passed to ArmMotion is %d", angle);
+    logger.logWarning(buf);
+    return;
+  }
+
+  // angleが60より大きい場合はwarningを出してangleを60にする
+  if(angle > 60) {
+    snprintf(buf, BUF_SIZE, "The angle value passed to ArmMotion is %d", angle);
+    logger.logWarning(buf);
+    angle = 60;
+  }
+
+  // angleが-60より小さい場合はwarningを出してangleを-60にする
+  if(angle < -60) {
+    snprintf(buf, BUF_SIZE, "The angle value passed to ArmMotion is %d", angle);
+    logger.logWarning(buf);
+    angle = -60;
+  }
+
+  while(true) {
+    int currentCount = Measurer::getArmMotorCount();
+
+    if(angle > 0) {
+      if(currentCount < initCount - angle) {
+        break;
+      }
+      Controller::setArmMotorPwm(-pwm);
+    }else {
+      if(currentCount > initCount - angle) {
+        break;
+      }
+      Controller::setArmMotorPwm(pwm);
+    }
+    
+    // 10ミリ秒待機
+    timer.sleep(10);
+  }
+
+  //アームモータの停止
+  Controller::stopArmMotor();
+}
+
+void ArmMotion::logRunning()
+{
+  const int BUF_SIZE = 256;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+
+  snprintf(buf, BUF_SIZE, "Run ArmMotion (angle: %d, pwm: %d)", angle, pwm);
+  logger.log(buf);
+}

--- a/module/Motion/ArmMotion.cpp
+++ b/module/Motion/ArmMotion.cpp
@@ -60,13 +60,13 @@ void ArmMotion::run()
         break;
       }
       Controller::setArmMotorPwm(-pwm);
-    }else {
+    } else {
       if(currentCount > initCount - angle) {
         break;
       }
       Controller::setArmMotorPwm(pwm);
     }
-    
+
     // 10ミリ秒待機
     timer.sleep(10);
   }

--- a/module/Motion/ArmMotion.h
+++ b/module/Motion/ArmMotion.h
@@ -1,0 +1,40 @@
+/**
+ * @file ArmMotion.h
+ * @brief アーム動作クラス
+ * @author KakinokiKanta
+ */
+
+#ifndef ARM_MOTION_H
+#define ARM_MOTION_H
+
+#include "Motion.h"
+#include "Measurer.h"
+#include "Controller.h"
+#include "Timer.h"
+
+class ArmMotion : public Motion {
+ public:
+  /**
+   * コンストラクタ
+   * @param _angle アームを上下する角度 0~60
+   * @param _pwm PWM値 0~40
+   */
+  ArmMotion(int _angle, int _pwm);
+
+  /**
+   * @brief アームを動かす
+   */
+  void run() override;
+
+  /**
+   * @brief 実行のログを取る
+   */
+  void logRunning() override;
+
+ private:
+  int angle;  // 回転角度(deg) -60~60
+  int pwm;    // PWM値 0~40
+  Timer timer;
+};
+
+#endif

--- a/module/Motion/BlockThrowing.cpp
+++ b/module/Motion/BlockThrowing.cpp
@@ -1,0 +1,48 @@
+/**
+ * @file   BlockThrowing.cpp
+ * @brief  ブロック投げ入れ動作
+ * @author KakinokiKanta
+ */
+
+#include "BlockThrowing.h"
+
+using namespace std;
+
+BlockThrowing::BlockThrowing(){};
+
+void BlockThrowing::run()
+{
+  ArmMotion raiseAM(armTargetAngle, armPwm);
+  ArmMotion lowerAM(-armTargetAngle, armPwm);
+  PwmRotation prePR(preTargetAngle, rotationPwm, isClockwise);
+  PwmRotation postPR(postTargetAngle, rotationPwm, !isClockwise);
+  DistanceStraight preDS(targetDistance, targetSpeed);
+  DistanceStraight postDS(targetDistance, -targetSpeed);
+  Sleeping sl(500);
+
+  // ブロック投げ入れのための回頭と前進をする
+  prePR.run();
+  sl.run();
+  preDS.run();
+
+  // アームを上げてブロックを放す
+  raiseAM.run();
+
+  // 復帰のための後退と回頭をする
+  postDS.run();
+  sl.run();
+  postPR.run();
+
+  // アームを下げる
+  sl.run();
+  lowerAM.run();
+}
+
+void BlockThrowing::logRunning()
+{
+  const int BUF_SIZE = 256;
+  char buf[BUF_SIZE];  // log用にメッセージを一時保持する領域
+
+  snprintf(buf, BUF_SIZE, "Run BlockThrowing");
+  logger.log(buf);
+}

--- a/module/Motion/BlockThrowing.h
+++ b/module/Motion/BlockThrowing.h
@@ -30,13 +30,13 @@ class BlockThrowing : public CompositeMotion {
   void logRunning() override;
 
  private:
-  const bool isClockwise = true;            // ブロック投げ入れの回頭方向
-  const int armTargetAngle = 60;    // アームの目標回転角度
-  const int preTargetAngle = 35;          // ブロック投げ入れのための目標回頭角度
-  const int postTargetAngle = 32;         // 復帰するための目標回頭角度
-  const int armPwm = 40;    // アーム動作のPWM
-  const int rotationPwm = 80;  // 回頭PWM
+  const bool isClockwise = true;      // ブロック投げ入れの回頭方向
+  const int armTargetAngle = 60;      // アームの目標回転角度
+  const int preTargetAngle = 35;      // ブロック投げ入れのための目標回頭角度
+  const int postTargetAngle = 32;     // 復帰するための目標回頭角度
+  const int armPwm = 40;              // アーム動作のPWM
+  const int rotationPwm = 80;         // 回頭PWM
   const double targetDistance = 100;  // ブロック投げ入れのための目標距離
-  const double targetSpeed = 150;    // ブロック投げ入れのための目標速度
+  const double targetSpeed = 150;     // ブロック投げ入れのための目標速度
 };
 #endif

--- a/module/Motion/BlockThrowing.h
+++ b/module/Motion/BlockThrowing.h
@@ -1,0 +1,42 @@
+/**
+ * @file   BlockThrowing
+ * @brief  ブロック投げ入れ動作
+ * @author KakinokiKanta
+ */
+
+#ifndef BLOCK_THROWING_H
+#define BLOCK_THROWING_H
+
+#include "SystemInfo.h"
+#include "CompositeMotion.h"
+#include "PwmRotation.h"
+#include "ArmMotion.h"
+#include "DistanceStraight.h"
+#include "Sleeping.h"
+
+class BlockThrowing : public CompositeMotion {
+ public:
+  // コンストラクタ
+  BlockThrowing();
+
+  /**
+   * @brief ブロック投げ入れ動作を行う
+   */
+  void run() override;
+
+  /**
+   * @brief 実行のログを取る
+   */
+  void logRunning() override;
+
+ private:
+  const bool isClockwise = true;            // ブロック投げ入れの回頭方向
+  const int armTargetAngle = 60;    // アームの目標回転角度
+  const int preTargetAngle = 35;          // ブロック投げ入れのための目標回頭角度
+  const int postTargetAngle = 32;         // 復帰するための目標回頭角度
+  const int armPwm = 40;    // アーム動作のPWM
+  const int rotationPwm = 80;  // 回頭PWM
+  const double targetDistance = 100;  // ブロック投げ入れのための目標距離
+  const double targetSpeed = 150;    // ブロック投げ入れのための目標速度
+};
+#endif

--- a/module/MotionParser.cpp
+++ b/module/MotionParser.cpp
@@ -1,7 +1,7 @@
 /**
  * @file   MotionParser.cpp
  * @brief  動作コマンドファイルを解析するクラス
- * @author aridome222 bizyutyu
+ * @author aridome222 bizyutyu KakinokiKanta
  */
 
 #include "MotionParser.h"
@@ -104,17 +104,13 @@ vector<Motion*> MotionParser::createMotions(const char* commandFilePath, int tar
                                                 atoi(params[3]));  // 右モータのPWM値
 
       motionList.push_back(dt);                                    // 動作リストに追加
-    } else if(command == COMMAND::AU) {  // アームを上げる
-      ArmUpping* au = new ArmUpping(atoi(params[1]), atoi(params[2]));
-
-      motionList.push_back(au);          // 動作リストに追加
-    } else if(command == COMMAND::AD) {  // アームを下げる
-      ArmDownning* ad = new ArmDownnig(atoi(params[1]), atoi(params[2]));
-
-      motionList.push_back(ad);          // 動作リストに追加
     }
     */
-    else if(command == COMMAND::XR) {  // 角度補正回頭の追加
+    else if(command == COMMAND::AM) {  // アーム動作の追加
+      ArmMotion* am = new ArmMotion(atoi(params[1]), atoi(params[2]));
+
+      motionList.push_back(am);          // 動作リストに追加
+    } else if(command == COMMAND::XR) {  // 角度補正回頭の追加
       CorrectingRotation* xr = new CorrectingRotation(atoi(params[1]),   // 目標角度
                                                       atof(params[2]));  // 目標速度
 
@@ -172,6 +168,10 @@ vector<Motion*> MotionParser::createMotions(const char* commandFilePath, int tar
       Stop* st = new Stop();
 
       motionList.push_back(st);  // 動作リストに追加
+    } else if(command == COMMAND::BT) {  // ブロック投げ入れ
+      BlockThrowing* bt = new BlockThrowing();
+
+      motionList.push_back(bt);  // 動作リストに追加
     } else {                     // 未定義のコマンドの場合
       snprintf(buf, BUF_SIZE, "%s:%d: '%s' is undefined command", commandFilePath, lineNum,
                params[0]);
@@ -204,10 +204,8 @@ COMMAND MotionParser::convertCommand(char* str)
     return COMMAND::EC;
   } else if(strcmp(str, "SL") == 0) {  // 文字列がSLの場合
     return COMMAND::SL;
-  } else if(strcmp(str, "AU") == 0) {  // 文字列がAUの場合
-    return COMMAND::AU;
-  } else if(strcmp(str, "AD") == 0) {  // 文字列がADの場合
-    return COMMAND::AD;
+  } else if(strcmp(str, "AM") == 0) {  // 文字列がAMの場合
+    return COMMAND::AM;
   } else if(strcmp(str, "XR") == 0) {  // 文字列がXRの場合
     return COMMAND::XR;
   } else if(strcmp(str, "CA") == 0) {  // 文字列がCAの場合
@@ -226,6 +224,8 @@ COMMAND MotionParser::convertCommand(char* str)
     return COMMAND::PR;
   } else if(strcmp(str, "ST") == 0) {  // 文字列がSTの場合
     return COMMAND::ST;
+  } else if(strcmp(str, "BT") == 0) {  // 文字列がBTの場合
+    return COMMAND::BT;
   } else {  // 想定していない文字列が来た場合
     return COMMAND::NONE;
   }

--- a/module/MotionParser.cpp
+++ b/module/MotionParser.cpp
@@ -167,7 +167,7 @@ vector<Motion*> MotionParser::createMotions(const char* commandFilePath, int tar
     } else if(command == COMMAND::ST) {  // 左右モーターストップ
       Stop* st = new Stop();
 
-      motionList.push_back(st);  // 動作リストに追加
+      motionList.push_back(st);          // 動作リストに追加
     } else if(command == COMMAND::BT) {  // ブロック投げ入れ
       BlockThrowing* bt = new BlockThrowing();
 

--- a/module/MotionParser.h
+++ b/module/MotionParser.h
@@ -1,7 +1,7 @@
 /**
  * @file   MotionParser.h
  * @brief  動作コマンドファイルを解析するクラス
- * @author aridome222 bizyutyu
+ * @author aridome222 bizyutyu KakinokiKanta
  */
 
 #ifndef MOTION_PARSER_H
@@ -30,6 +30,8 @@
 #include "CameraAction.h"
 #include "PwmRotation.h"
 #include "Stop.h"
+#include "ArmMotion.h"
+#include "BlockThrowing.h"
 
 enum class COMMAND {
   DL,  // 指定距離ライントレース
@@ -40,8 +42,7 @@ enum class COMMAND {
   DT,  // 旋回
   EC,  // エッジ切り替え
   SL,  // 自タスクスリープ
-  AU,  // アームを上げる
-  AD,  // アームを下げる
+  AM,  // アーム動作
   XR,  // 角度補正回頭
   CA,  // 撮影動作
   IS,  // 交点内移動（直進）
@@ -51,6 +52,7 @@ enum class COMMAND {
   CM,  // 交点サークルから直線の中点
   PR,  // Pwm値指定回頭
   ST,  // 左右モーターストップ
+  BT,
   NONE
 };
 

--- a/test/ArmMotionTest.cpp
+++ b/test/ArmMotionTest.cpp
@@ -1,7 +1,7 @@
 /**
  *  @file   ArmMotionTest.cpp
  *  @brief  ArmMotionクラスのテスト
- *  @author Negimarge
+ *  @author bizyutyu
  */
 
 #include "ArmMotion.h"

--- a/test/ArmMotionTest.cpp
+++ b/test/ArmMotionTest.cpp
@@ -1,0 +1,190 @@
+/**
+ *  @file   ArmMotionTest.cpp
+ *  @brief  ArmMotionクラスのテスト
+ *  @author Negimarge
+ */
+
+#include "ArmMotion.h"
+#include <gtest/gtest.h>
+#include "Measurer.h"
+#include "Controller.h"
+
+using namespace std;
+
+namespace etrobocon2023_test {
+  TEST(ArmMotionTest, runPlusAngle)
+  {
+    // PWMの初期化
+    Controller::stopArmMotor();
+    // アームモータ角位置を初期化
+    Measurer::resetArmMotorCount();
+    int armTargetAngle = 60;
+    int armPwm = 40;
+    ArmMotion am(armTargetAngle, armPwm);
+
+    // 初期値
+    int ArmMotorCount = Measurer::getArmMotorCount();
+
+    // 期待するアーム角位置
+    int expected = -60;
+
+    am.run();  // アーム動作を実行
+
+    // 関数実行後のアーム角位置
+    int actual = Measurer::getArmMotorCount() - ArmMotorCount;
+
+    // アーム角位置のテスト
+    EXPECT_GE(expected, actual);
+  }
+
+  TEST(ArmMotionTest, runMinusAngle)
+  {
+    // PWMの初期化
+    Controller::stopArmMotor();
+    // アームモータ角位置を初期化
+    Measurer::resetArmMotorCount();
+    int armTargetAngle = -60;
+    int armPwm = 40;
+    ArmMotion am(armTargetAngle, armPwm);
+
+    // 初期値
+    int ArmMotorCount = Measurer::getArmMotorCount();
+
+    // 期待するアーム角位置
+    int expected = 60;
+
+    am.run();  // アーム動作を実行
+
+    // 関数実行後のアーム角位置
+    int actual = Measurer::getArmMotorCount() - ArmMotorCount;
+
+    // アーム角位置のテスト
+    EXPECT_LE(expected, actual);
+  }
+
+  TEST(ArmMotionTest, runZeroAngle)
+  {
+    // PWMの初期化
+    Controller::stopArmMotor();
+    // アームモータ角位置を初期化
+    Measurer::resetArmMotorCount();
+    int armTargetAngle = 0;
+    int armPwm = 40;
+    ArmMotion am(armTargetAngle, armPwm);
+
+    // 初期値
+    int ArmMotorCount = Measurer::getArmMotorCount();
+
+    // 期待するアーム角位置
+    int expected = 0;
+
+    am.run();  // アーム動作を実行
+
+    // 関数実行後のアーム角位置
+    int actual = Measurer::getArmMotorCount() - ArmMotorCount;
+
+    // アーム角位置のテスト
+    EXPECT_EQ(expected, actual);
+  }
+
+  TEST(ArmMotionTest, runOver60Angle)
+  {
+    // PWMの初期化
+    Controller::stopArmMotor();
+    // アームモータ角位置を初期化
+    Measurer::resetArmMotorCount();
+    int armTargetAngle = 61;
+    int armPwm = 40;
+    ArmMotion am(armTargetAngle, armPwm);
+
+    // 初期値
+    int ArmMotorCount = Measurer::getArmMotorCount();
+
+    // 期待するアーム角位置
+    int expected = -60;
+
+    am.run();  // アーム動作を実行
+
+    // 関数実行後のアーム角位置
+    int actual = Measurer::getArmMotorCount() - ArmMotorCount;
+
+    // アーム角位置のテスト
+    EXPECT_GE(expected, actual);
+  }
+
+  TEST(ArmMotionTest, runUnder60Angle)
+  {
+    // PWMの初期化
+    Controller::stopArmMotor();
+    // アームモータ角位置を初期化
+    Measurer::resetArmMotorCount();
+    int armTargetAngle = -61;
+    int armPwm = 40;
+    ArmMotion am(armTargetAngle, armPwm);
+
+    // 初期値
+    int ArmMotorCount = Measurer::getArmMotorCount();
+
+    // 期待するアーム角位置
+    int expected = 60;
+
+    am.run();  // アーム動作を実行
+
+    // 関数実行後のアーム角位置
+    int actual = Measurer::getArmMotorCount() - ArmMotorCount;
+
+    // アーム角位置のテスト
+    EXPECT_LE(expected, actual);
+  }
+
+  TEST(ArmMotionTest, runMinusPWM)
+  {
+    // PWMの初期化
+    Controller::stopArmMotor();
+    // アームモータ角位置を初期化
+    Measurer::resetArmMotorCount();
+    int armTargetAngle = 60;
+    int armPwm = -30;
+    ArmMotion am(armTargetAngle, armPwm);
+
+    // 初期値
+    int ArmMotorCount = Measurer::getArmMotorCount();
+
+    // 期待するアーム角位置
+    int expected = 0;
+
+    am.run();  // アーム動作を実行
+
+    // 関数実行後のアーム角位置
+    int actual = Measurer::getArmMotorCount() - ArmMotorCount;
+
+    // アーム角位置のテスト
+    EXPECT_EQ(expected, actual);
+  }
+
+  TEST(ArmMotionTest, runZeroPWM)
+  {
+    // PWMの初期化
+    Controller::stopArmMotor();
+    // アームモータ角位置を初期化
+    Measurer::resetArmMotorCount();
+    int armTargetAngle = 20;
+    int armPwm = 0;
+    ArmMotion am(armTargetAngle, armPwm);
+
+    // 初期値
+    int ArmMotorCount = Measurer::getArmMotorCount();
+
+    // 期待するアーム角位置
+    int expected = 0;
+
+    am.run();  // アーム動作を実行
+
+    // 関数実行後のアーム角位置
+    int actual = Measurer::getArmMotorCount() - ArmMotorCount;
+
+    // アーム角位置のテスト
+    EXPECT_EQ(expected, actual);
+  }
+
+}  // namespace etrobocon2023_test


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- アーム動作用クラスの追加
- ブロック投げ入れ用クラスの追加
- 上記クラスに対応するコマンド(AM, BT)の追加
- アーム動作のテストの追加（ブロック投げ入れ動作に関しては他の応用動作と同じく、テスト未作成）
- アームモータカウントの更新と初期化の関数を追加

# 動作テスト

https://github.com/KatLab-MiyazakiUniv/etrobocon2023/assets/105735727/58e48e69-20dc-4057-b15d-16f712df173e

当初予定していた回頭の勢いでブロックを投げる動作については、回頭角度が45度では安定しなかったため、全身と後退を挟んでいます。

*体調崩してて、~~テストは書けてないです。~~ 動画を載せてるので、それ確認してください。